### PR TITLE
Pin rest-client and dep for Ruby 1.8 compatibility

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -11,6 +11,23 @@ Gemfile:
   - gem: simplecov
   - gem: puppet-blacksmith
     version: '>= 3.1.0'
+    options:
+      groups:
+      - 'development'
+  - gem: rest-client
+    version: '< 1.7'
+    options:
+      platforms:
+      - 'ruby_18'
+      groups:
+      - 'development'
+  - gem: mime-types
+    version: '~> 1.0'
+    options:
+      platforms:
+      - 'ruby_18'
+      groups:
+      - 'development'
 .puppet-lint.rc:
   default_disabled_lint_checks:
   - '80chars'

--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -18,3 +18,4 @@ matrix:
     # No support for Ruby 2.0 before Puppet 3.2
     - rvm: 2.0.0
       env: PUPPET_VERSION=2.7.0
+bundler_args: --without development

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org'
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 2.7'
 
 <% (@configs['required'] + (@configs['extra'] || [])).each do |gem| -%>
-gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %>
+gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %><%= ", #{gem['options'].inspect}" if gem['options'] %>
 <% end -%>
 
 # vim:ft=ruby

--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -3,13 +3,17 @@
 
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
-require 'puppet_blacksmith/rake_tasks'
+
+# blacksmith isn't always present, e.g. on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+  Blacksmith::RakeTask.new do |t|
+    t.tag_pattern = "%s"
+  end
+rescue LoadError
+end
 
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "vendor/**/*.pp"]
 PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{KIND}: %{message}'
-
-Blacksmith::RakeTask.new do |t|
-  t.tag_pattern = "%s"
-end
 
 task :default => [:validate, :lint, :spec]


### PR DESCRIPTION
@ekohl do you mind a bit of ugliness in the generated files, in exchange for a nicer yml file?

---

<pre>
$ msync update --noop
Syncing puppet-concat
Overriding any local changes to repositories in ./modules
No config file under ./modules/puppet-concat/.sync.yml found, using default values
Using no-op. Files in puppet-concat may be changed but will not be committed.
Files changed: 
diff --git a/Gemfile b/Gemfile
index 136773d..d417910 100644
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,7 @@ gem 'puppetlabs_spec_helper', '&gt;= 0.8.0'
 gem 'puppet-lint', '&gt;= 1'
 gem 'simplecov'
 gem 'puppet-blacksmith', '&gt;= 3.1.0'
+gem 'rest-client', '&lt; 1.7', {"platforms"=&gt;["ruby_18"]}
+gem 'mime-types', '~&gt; 1.0', {"platforms"=&gt;["ruby_18"]}
 
 # vim:ft=ruby
Files added: 


--------------------------------
Syncing puppet-dhcp
Overriding any local changes to repositories in ./modules
Using no-op. Files in puppet-dhcp may be changed but will not be committed.
Files changed: 
diff --git a/Gemfile b/Gemfile
index 136773d..d417910 100644
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,7 @@ gem 'puppetlabs_spec_helper', '&gt;= 0.8.0'
 gem 'puppet-lint', '&gt;= 1'
 gem 'simplecov'
 gem 'puppet-blacksmith', '&gt;= 3.1.0'
+gem 'rest-client', '&lt; 1.7', {"platforms"=&gt;["ruby_18"]}
+gem 'mime-types', '~&gt; 1.0', {"platforms"=&gt;["ruby_18"]}
 
 # vim:ft=ruby
Files added: 


--------------------------------
Syncing puppet-dns
Overriding any local changes to repositories in ./modules
No config file under ./modules/puppet-dns/.sync.yml found, using default values
Using no-op. Files in puppet-dns may be changed but will not be committed.
Files changed: 
diff --git a/Gemfile b/Gemfile
index 136773d..d417910 100644
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,7 @@ gem 'puppetlabs_spec_helper', '&gt;= 0.8.0'
 gem 'puppet-lint', '&gt;= 1'
 gem 'simplecov'
 gem 'puppet-blacksmith', '&gt;= 3.1.0'
+gem 'rest-client', '&lt; 1.7', {"platforms"=&gt;["ruby_18"]}
+gem 'mime-types', '~&gt; 1.0', {"platforms"=&gt;["ruby_18"]}
 
 # vim:ft=ruby
Files added: 


--------------------------------
Syncing puppet-foreman
Overriding any local changes to repositories in ./modules
Using no-op. Files in puppet-foreman may be changed but will not be committed.
Files changed: 
diff --git a/Gemfile b/Gemfile
index 385d6a1..460ffd3 100644
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'puppetlabs_spec_helper', '&gt;= 0.8.0'
 gem 'puppet-lint', '&gt;= 1'
 gem 'simplecov'
 gem 'puppet-blacksmith', '&gt;= 3.1.0'
+gem 'rest-client', '&lt; 1.7', {"platforms"=&gt;["ruby_18"]}
+gem 'mime-types', '~&gt; 1.0', {"platforms"=&gt;["ruby_18"]}
 gem 'json'
 gem 'webmock'
 
Files added: 


--------------------------------
Syncing puppet-foreman_proxy
Overriding any local changes to repositories in ./modules
No config file under ./modules/puppet-foreman_proxy/.sync.yml found, using default values
Using no-op. Files in puppet-foreman_proxy may be changed but will not be committed.
Files changed: 
diff --git a/Gemfile b/Gemfile
index 136773d..d417910 100644
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,7 @@ gem 'puppetlabs_spec_helper', '&gt;= 0.8.0'
 gem 'puppet-lint', '&gt;= 1'
 gem 'simplecov'
 gem 'puppet-blacksmith', '&gt;= 3.1.0'
+gem 'rest-client', '&lt; 1.7', {"platforms"=&gt;["ruby_18"]}
+gem 'mime-types', '~&gt; 1.0', {"platforms"=&gt;["ruby_18"]}
 
 # vim:ft=ruby
Files added: 


--------------------------------
Syncing puppet-git
Overriding any local changes to repositories in ./modules
No config file under ./modules/puppet-git/.sync.yml found, using default values
Using no-op. Files in puppet-git may be changed but will not be committed.
Files changed: 
diff --git a/Gemfile b/Gemfile
index 136773d..d417910 100644
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,7 @@ gem 'puppetlabs_spec_helper', '&gt;= 0.8.0'
 gem 'puppet-lint', '&gt;= 1'
 gem 'simplecov'
 gem 'puppet-blacksmith', '&gt;= 3.1.0'
+gem 'rest-client', '&lt; 1.7', {"platforms"=&gt;["ruby_18"]}
+gem 'mime-types', '~&gt; 1.0', {"platforms"=&gt;["ruby_18"]}
 
 # vim:ft=ruby
Files added: 


--------------------------------
Syncing puppet-puppet
Overriding any local changes to repositories in ./modules
Using no-op. Files in puppet-puppet may be changed but will not be committed.
Files changed: 
diff --git a/Gemfile b/Gemfile
index 136773d..d417910 100644
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,7 @@ gem 'puppetlabs_spec_helper', '&gt;= 0.8.0'
 gem 'puppet-lint', '&gt;= 1'
 gem 'simplecov'
 gem 'puppet-blacksmith', '&gt;= 3.1.0'
+gem 'rest-client', '&lt; 1.7', {"platforms"=&gt;["ruby_18"]}
+gem 'mime-types', '~&gt; 1.0', {"platforms"=&gt;["ruby_18"]}
 
 # vim:ft=ruby
Files added: 


--------------------------------
Syncing puppet-tftp
Overriding any local changes to repositories in ./modules
No config file under ./modules/puppet-tftp/.sync.yml found, using default values
Using no-op. Files in puppet-tftp may be changed but will not be committed.
Files changed: 
diff --git a/Gemfile b/Gemfile
index 136773d..d417910 100644
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,7 @@ gem 'puppetlabs_spec_helper', '&gt;= 0.8.0'
 gem 'puppet-lint', '&gt;= 1'
 gem 'simplecov'
 gem 'puppet-blacksmith', '&gt;= 3.1.0'
+gem 'rest-client', '&lt; 1.7', {"platforms"=&gt;["ruby_18"]}
+gem 'mime-types', '~&gt; 1.0', {"platforms"=&gt;["ruby_18"]}
 
 # vim:ft=ruby
Files added: 


--------------------------------
</pre>
