### PR TITLE
Add new puppet-lint checks for Puppet 4 compatibility

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -8,6 +8,15 @@ Gemfile:
     version: '>= 0.8.0'
   - gem: puppet-lint
     version: '>= 1'
+  - gem: puppet-lint-unquoted_string-check
+  - gem: puppet-lint-empty_string-check
+  - gem: puppet-lint-spaceship_operator_without_tag-check
+  - gem: puppet-lint-variable_contains_upcase
+  - gem: puppet-lint-absolute_classname-check
+  - gem: puppet-lint-undef_in_function-check
+  - gem: puppet-lint-leading_zero-check
+  - gem: puppet-lint-trailing_comma-check
+  - gem: puppet-lint-file_ensure-check
   - gem: simplecov
   - gem: puppet-blacksmith
     version: '>= 3.1.0'


### PR DESCRIPTION
From http://www.camptocamp.com/actualite/getting-code-ready-puppet-4/

---

I'll open up per-module PRs to show where we have failures and then we can work to fix them.

- https://github.com/theforeman/puppet-concat_native/pull/7 (merged)
- https://github.com/theforeman/puppet-dhcp/pull/39 (merged)
- https://github.com/theforeman/puppet-dns/pull/27 (merged)
- https://github.com/theforeman/puppet-foreman/pull/293 (merged)
- https://github.com/theforeman/puppet-foreman_proxy/pull/153 (merged)
- https://github.com/theforeman/puppet-git/pull/12 (merged)
- https://github.com/theforeman/puppet-puppet/pull/242 (merged)
- https://github.com/theforeman/puppet-tftp/pull/28 (merged)