### PR TITLE
Enable future parser tests

### DIFF
--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -9,6 +9,7 @@ rvm:
 env:
   - PUPPET_VERSION=2.7.0
   - PUPPET_VERSION=3.5
+  - PUPPET_VERSION=3.5 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
 matrix:
   exclude:
     # No real support for Ruby 1.9.3 on Puppet 2.x


### PR DESCRIPTION
I didn't enable strict variables as we already know that's more of a bloodbath due to variables uninitialised during tests.  Let's do that as the next step?

* [x] https://github.com/theforeman/puppet-concat_native/pull/8
* [x] https://github.com/theforeman/puppet-dhcp/pull/41
* [x] https://github.com/theforeman/puppet-dns/pull/31
* [x] https://github.com/theforeman/puppet-foreman/pull/306
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/163
* [x] https://github.com/theforeman/puppet-git/pull/13
* [x] https://github.com/theforeman/puppet-puppet/pull/250
* [x] https://github.com/theforeman/puppet-tftp/pull/29

Early indications are pretty good.  We have some scoping issues in templates in a couple of places (leading to us calling methods on nil objects) and use of private() needs to be removed as it's badly named and is changing in stdlib.