### PR TITLE
Pin rspec to < 3.2.0 on Ruby 1.8.7

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -39,6 +39,11 @@ Gemfile:
       - 'development'
   - gem: rspec-puppet-facts
   - gem: metadata-json-lint
+  - gem: rspec
+    version: '< 3.2.0'
+    options:
+      platforms:
+      - 'ruby_18'
 .puppet-lint.rc:
   default_disabled_lint_checks:
   - '80chars'


### PR DESCRIPTION
Caused by Puppet monkey patches (rspec/rspec-core#1864)

---

I'm seeing this now on module tests, e.g. https://travis-ci.org/domcleal/puppet-tftp/jobs/54222435.  rspec-puppet 2.0.1 was released yesterday which lifted the pinning of rspec to 2.x so module authors have the choice to use 3.x.

I'll push branches to our modules so we can see the tests run there.


* [x] https://github.com/theforeman/puppet-concat_native/pull/9
* [x] https://github.com/theforeman/puppet-dhcp/pull/42
* [x] https://github.com/theforeman/puppet-dns/pull/32
* [x] https://github.com/theforeman/puppet-foreman/pull/307
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/164
* [x] https://github.com/theforeman/puppet-git/pull/14
* [x] https://github.com/theforeman/puppet-puppet/pull/252
* [x] https://github.com/theforeman/puppet-tftp/pull/30