### PR TITLE
Add param docs lint check

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -17,6 +17,8 @@ Gemfile:
   - gem: puppet-lint-leading_zero-check
   - gem: puppet-lint-trailing_comma-check
   - gem: puppet-lint-file_ensure-check
+  - gem: puppet-lint-param-docs
+    version: '>= 1.3.0'
   - gem: simplecov
   - gem: puppet-blacksmith
     version: '>= 3.1.0'
@@ -50,3 +52,5 @@ Gemfile:
   - 'class_inherits_from_params_class'
 spec/spec_helper.rb:
   requires: []
+Rakefile:
+  param_docs_pattern: []

--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -16,4 +16,9 @@ end
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "vendor/**/*.pp"]
 PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{KIND}: %{message}'
 
+require 'puppet-lint-param-docs/tasks'
+PuppetLintParamDocs.define_selective do |config|
+  config.pattern = <%= @configs['param_docs_pattern'].inspect %>
+end
+
 task :default => [:validate, :lint, :spec]


### PR DESCRIPTION
Does not test any files by default, needs to be enabled in the
per-module msync configs.

(So this is safe to merge, I can run msync after and then enable it on a per-module basis.)