### PR TITLE
Add our verify_* helpers for file and concat fragment contents

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -13,4 +13,23 @@ include RspecPuppetFacts
 class Undef
   def inspect; 'undef'; end
 end
+
+def get_content(subject, title)
+  content = subject.resource('file', title).send(:parameters)[:content]
+  content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }
+end
+
+def verify_exact_contents(subject, title, expected_lines)
+  expect(get_content(subject, title)).to eq(expected_lines)
+end
+
+def verify_concat_fragment_contents(subject, title, expected_lines)
+  content = subject.resource('concat::fragment', title).send(:parameters)[:content]
+    (content.split("\n") & expected_lines).should == expected_lines
+end
+
+def verify_concat_fragment_exact_contents(subject, title, expected_lines)
+  content = subject.resource('concat::fragment', title).send(:parameters)[:content]
+    content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }.should == expected_lines
+end
 <%= "\n" + @configs['extra_code'] if @configs['extra_code'] -%>


### PR DESCRIPTION
I think they're all compatible with each other, so this collects them all into one place, then we can just remove the spec/lib/ files and requires entries from .sync.yml.