### PR TITLE
Fix rspec-expectations should vs expect deprecation warning

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -25,11 +25,11 @@ end
 
 def verify_concat_fragment_contents(subject, title, expected_lines)
   content = subject.resource('concat::fragment', title).send(:parameters)[:content]
-    (content.split("\n") & expected_lines).should == expected_lines
+  expect(content.split("\n") & expected_lines).to eq(expected_lines)
 end
 
 def verify_concat_fragment_exact_contents(subject, title, expected_lines)
   content = subject.resource('concat::fragment', title).send(:parameters)[:content]
-    content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }.should == expected_lines
+    expect(content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }).to eq(expected_lines)
 end
 <%= "\n" + @configs['extra_code'] if @configs['extra_code'] -%>


### PR DESCRIPTION
Fixes a deprecation warning:

```
Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /tmp/puppet/modules/upstream/puppet/spec/spec_helper.rb:30:in `verify_concat_fragment_exact_contents'.
```