### PR TITLE
Set minimum rspec version to 3.0

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -41,11 +41,6 @@ Gemfile:
       - 'development'
   - gem: rspec-puppet-facts
   - gem: metadata-json-lint
-  - gem: rspec
-    version: '< 3.2.0'
-    options:
-      platforms:
-      - 'ruby_18'
 .puppet-lint.rc:
   default_disabled_lint_checks:
   - '80chars'

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -5,6 +5,11 @@ source 'https://rubygems.org'
 
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 2.7'
 
+if RUBY_VERSION.start_with? '1.8'
+  gem 'rspec', '>= 3', '< 3.2'
+else
+  gem 'rspec', '~> 3.0'
+end
 <% (@configs['required'] + (@configs['extra'] || [])).each do |gem| -%>
 gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %><%= ", #{gem['options'].inspect}" if gem['options'] %>
 <% end -%>


### PR DESCRIPTION
Moves the rspec gem from the configurable list into the Gemfile
template itself, as the Ruby 1.8 requirement can't be expressed in the
YAML format easily.  Rspec 3.1 is still required for Ruby 1.8 as per
commit 29d3cd8.

Moving to rspec 3.0 as a minimum will allow some deprecation warnings
to be fixed.