### PR TITLE
Avoid blacksmith error with Ruby 1.8.7

### DIFF
--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -4,13 +4,16 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 
-# blacksmith isn't always present, e.g. on Travis with --without development
-begin
-  require 'puppet_blacksmith/rake_tasks'
-  Blacksmith::RakeTask.new do |t|
-    t.tag_pattern = "%s"
+# blacksmith is broken with ruby 1.8.7
+if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('1.8.7')
+  # blacksmith isn't always present, e.g. on Travis with --without development
+  begin
+    require 'puppet_blacksmith/rake_tasks'
+    Blacksmith::RakeTask.new do |t|
+      t.tag_pattern = "%s"
+    end
+  rescue LoadError
   end
-rescue LoadError
 end
 
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "vendor/**/*.pp"]


### PR DESCRIPTION
With 1.8.7, an exception is generated by ruby if blacksmith is present:

```
rake aborted!
NoMethodError: undefined method `upcase' for :major:Symbol
puppet-puppet/Rakefile:9:in `require'
puppet-puppet/Rakefile:9
(See full trace by running task with --trace)
```

This commit ignores that error if Ruby 1.8.7 is being used.