### PR TITLE
Add workaround for rspec-puppet instance variable memory usage

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -51,7 +51,7 @@ def verify_concat_fragment_exact_contents(subject, title, expected_lines)
     expect(content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }).to eq(expected_lines)
 end
 
-# See https://github.com/rodjek/rspec-puppet/issues/215
+# See https://github.com/rodjek/rspec-puppet/issues/329
 # Without this patch the @@cache variable grows huge and causes memory usage issues
 # with a large amount of examples.
 module RSpec::Puppet
@@ -65,5 +65,12 @@ module RSpec::Puppet
       end
     end
   end
+end
+
+# See https://github.com/rodjek/rspec-puppet/pull/333
+# Prevents each generated catalog being held in memory after the example group has
+# completed.
+RSpec.configure do |c|
+  c.after(:each) { @catalogue = nil }
 end
 <%= "\n" + @configs['extra_code'] if @configs['extra_code'] -%>


### PR DESCRIPTION
Running a test build of puppet-puppet over here: https://travis-ci.org/domcleal/puppet-puppet/builds/93932305.  It should fix failures on Ruby 1.9.3 and 2.0.0.