### PR TITLE
run travis tests with Ruby 2.2

### DIFF
--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -2,10 +2,10 @@
 # This file is managed centrally by modulesync
 #   https://github.com/theforeman/foreman-installer-modulesync
 rvm:
-  - 2.1.5
-  - 2.0.0
-  - 1.9.3
   - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.5
 env:
   # First test the major distros
   - PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64
@@ -38,5 +38,9 @@ matrix:
       env: PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64,debian-6-x86_64
     - rvm: 1.8.7
       env: PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64,debian-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  include:
+    # Only Puppet 4.x supports Ruby 2.2. Also limit the OS set we test Ruby 2.2 with.
+    - rvm: 2.2.3
+      env: PUPPET_VERSION=4.0 ONLY_OS=debian-8-x86_64,centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
 bundler_args: --without development
 sudo: false


### PR DESCRIPTION
As I didn't manage to have Ruby 2.2 on the top with the include method, reversing the order again...
Green tests with 2.2 on all theforeman modules:
https://travis-ci.org/mmoll/puppet-git/jobs/94483914
https://travis-ci.org/mmoll/puppet-tftp/jobs/94484038
https://travis-ci.org/mmoll/puppet-dns/jobs/94483627
https://travis-ci.org/mmoll/puppet-dhcp/jobs/94482322
https://travis-ci.org/mmoll/puppet-puppet/jobs/94485329
https://travis-ci.org/mmoll/puppet-foreman/jobs/94486833
https://travis-ci.org/mmoll/puppet-foreman_proxy/jobs/94488178