### PR TITLE
Update to rspec-puppet 2.3.0, remove workarounds

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -3,7 +3,7 @@ Gemfile:
   required:
   - gem: rake
   - gem: rspec-puppet
-    version: '~> 2.0'
+    version: '~> 2.3'
   - gem: puppetlabs_spec_helper
     version: '>= 0.8.0'
   - gem: puppet-lint

--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -50,27 +50,4 @@ def verify_concat_fragment_exact_contents(subject, title, expected_lines)
   content = subject.resource('concat::fragment', title).send(:parameters)[:content]
     expect(content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }).to eq(expected_lines)
 end
-
-# See https://github.com/rodjek/rspec-puppet/issues/329
-# Without this patch the @@cache variable grows huge and causes memory usage issues
-# with a large amount of examples.
-module RSpec::Puppet
-  module Support
-    def build_catalog(*args)
-      if @@cache.has_key?(args)
-        @@cache[args]
-      else
-        @@cache = {}
-        @@cache[args] ||= self.build_catalog_without_cache(*args)
-      end
-    end
-  end
-end
-
-# See https://github.com/rodjek/rspec-puppet/pull/333
-# Prevents each generated catalog being held in memory after the example group has
-# completed.
-RSpec.configure do |c|
-  c.after(:each) { @catalogue = nil }
-end
 <%= "\n" + @configs['extra_code'] if @configs['extra_code'] -%>


### PR DESCRIPTION
The current monkey patch will cause errors on 2.3.0 as the contents of `@@cache` are different to what they were.

Testing puppet-dhcp here and it seems OK: https://travis-ci.org/domcleal/puppet-dhcp/builds/96990516