### PR TITLE
Pin rake to < 11 for Ruby 1.8.7

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -1,7 +1,6 @@
 ---
 Gemfile:
   required:
-  - gem: rake
   - gem: rspec-puppet
     version: '~> 2.3'
   - gem: puppetlabs_spec_helper

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -6,9 +6,11 @@ source 'https://rubygems.org'
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 2.7'
 
 if RUBY_VERSION.start_with? '1.8'
+  gem 'rake', '< 11'
   gem 'rspec', '>= 3', '< 3.2'
   gem 'rspec-puppet-facts', '< 1.4.0'
 else
+  gem 'rake'
   gem 'rspec', '~> 3.0'
   gem 'rspec-puppet-facts'
 end


### PR DESCRIPTION
Should fix the error seen at https://github.com/theforeman/puppet-puppet/pull/356#issuecomment-194586010 and https://travis-ci.org/theforeman/puppet-puppet/jobs/114805305.