### PR TITLE
update OSes in test matrix

### DIFF
--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -11,13 +11,13 @@ env:
   - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
   - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64
   # Test operating systems with ruby 1.8.7 explicitly so we can exclude ruby 1.8.7 tests for other OS
-  - PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64,debian-6-x86_64
-  - PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64,debian-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64,debian-6-x86_64
+  - PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
+  - PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
   # Test the rest of the supported platforms
-  - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64,debian-6-x86_64
-  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64,debian-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64,debian-6-x86_64
+  - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
+  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
 matrix:
   fast_finish: true
   exclude:
@@ -25,17 +25,17 @@ matrix:
     - rvm: 1.9.3
       env: PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64
     - rvm: 1.9.3
-      env: PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64,debian-6-x86_64
+      env: PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
     - rvm: 1.9.3
-      env: PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64,debian-6-x86_64
+      env: PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
   include:
     # Only platforms left to support ruby 1.8.7
     - rvm: 1.8.7
-      env: PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64,debian-6-x86_64
+      env: PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
     - rvm: 1.8.7
-      env: PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64,debian-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+      env: PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
     # Only Puppet 4.x supports Ruby 2.2. Also limit the OS set we test Ruby 2.2 with.
     - rvm: 2.2.3
-      env: PUPPET_VERSION=4.0 ONLY_OS=debian-8-x86_64,centos-7-x86_64,ubuntu-14-x86_64,freebsd-10-amd64
+      env: PUPPET_VERSION=4.0 ONLY_OS="debian-8-x86_64,centos-7-x86_64,ubuntu-16-x86_64,freebsd-10-amd64,windows-2012 R2-x64"
 bundler_args: --without development
 sudo: false

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -12,7 +12,7 @@ if RUBY_VERSION.start_with? '1.8'
 else
   gem 'rake'
   gem 'rspec', '~> 3.0'
-  gem 'rspec-puppet-facts'
+  gem 'rspec-puppet-facts', '>= 1.5'
 end
 <% (@configs['required'] + (@configs['extra'] || [])).each do |gem| -%>
 gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %><%= ", #{gem['options'].inspect}" if gem['options'] %>


### PR DESCRIPTION
- remove Debian/squeeze
- test Ubuntu/xenial instead of Ubuntu/trusty with Ruby 2.2
- test Windows 2012 R2 on Ruby 2.2
- depend on rspec-puppet-facts >= 1.5 (for Windows support)