### PR TITLE
Pin json_pure on Ruby 1.8.7/1.9.3

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -38,6 +38,14 @@ Gemfile:
       - 'ruby_18'
       groups:
       - 'development'
+  - gem: json_pure
+    version: '~> 1.0'
+    options:
+      platforms:
+      - 'ruby_18'
+      - 'ruby_19'
+      groups:
+      - 'test'
   - gem: metadata-json-lint
 .puppet-lint.rc:
   default_disabled_lint_checks:


### PR DESCRIPTION
json_pure 2.0.0 has been released without 1.8 and 1.9 compatibility, so this pins it to 1.x on those platforms.

Failing test: https://travis-ci.org/theforeman/puppet-foreman/jobs/141567979
Currently running tests with the pin: https://travis-ci.org/domcleal/puppet-foreman/builds/141588250