### PR TITLE
Parameterise and enable strict variable testing

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -59,6 +59,8 @@ Gemfile:
   default_disabled_lint_checks:
   - '140chars'
   - 'class_inherits_from_params_class'
+.travis.yml:
+  strict_variables: 'yes'
 spec/spec_helper.rb:
   requires: []
 Rakefile:

--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -7,27 +7,27 @@ rvm:
   - 2.1.5
 env:
   # First test the major distros
-  - PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64
-  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64 STRICT_VARIABLES=<%= @configs['strict_variables'] %>
+  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes STRICT_VARIABLES=<%= @configs['strict_variables'] %>
   - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64
   # Test operating systems with ruby 1.8.7 explicitly so we can exclude ruby 1.8.7 tests for other OS
-  - PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
-  - PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 STRICT_VARIABLES=<%= @configs['strict_variables'] %>
+  - PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes STRICT_VARIABLES=<%= @configs['strict_variables'] %>
   - PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
   # Test the rest of the supported platforms
-  - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
-  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 STRICT_VARIABLES=<%= @configs['strict_variables'] %>
+  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes STRICT_VARIABLES=<%= @configs['strict_variables'] %>
   - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
 matrix:
   fast_finish: true
   exclude:
     # No support for Ruby 1.9.3 on Puppet 4.x
     - rvm: 1.9.3
-      env: PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64
+      env: PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64 STRICT_VARIABLES=<%= @configs['strict_variables'] %>
     - rvm: 1.9.3
-      env: PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
+      env: PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 STRICT_VARIABLES=<%= @configs['strict_variables'] %>
     - rvm: 1.9.3
-      env: PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
+      env: PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 STRICT_VARIABLES=<%= @configs['strict_variables'] %>
   include:
     # Only platforms left to support ruby 1.8.7
     - rvm: 1.8.7
@@ -36,9 +36,9 @@ matrix:
       env: PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
     # Only Puppet 4.x supports Ruby 2.2. Also limit the OS set we test Ruby 2.2 with.
     - rvm: 2.2.3
-      env: PUPPET_VERSION=4.0 ONLY_OS="debian-8-x86_64,centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,freebsd-10-amd64,windows-2012 R2-x64"
+      env: PUPPET_VERSION=4.0 ONLY_OS="debian-8-x86_64,centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,freebsd-10-amd64,windows-2012 R2-x64" STRICT_VARIABLES=<%= @configs['strict_variables'] %>
     # Only Puppet >= 4.4 supports Ruby 2.3. Also limit the OS set we test Ruby 2.3 with.
     - rvm: 2.3.0
-      env: PUPPET_VERSION=4.4 ONLY_OS="debian-8-x86_64,centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,freebsd-10-amd64,windows-2012 R2-x64"
+      env: PUPPET_VERSION=4.4 ONLY_OS="debian-8-x86_64,centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,freebsd-10-amd64,windows-2012 R2-x64" STRICT_VARIABLES=<%= @configs['strict_variables'] %>
 bundler_args: --without development
 sudo: false


### PR DESCRIPTION
puppetlabs_spec_helper 1.2.0 will enable strict variable testing by
default on Puppet 4.x, so provide a means to disable it per module and
also test on 3.x where it's available.

---

https://travis-ci.org/domcleal/puppet-dns/builds/154724569 is an example job with strict vars enabled.

I'm not certain which modules are fully compatible or not. I know that puppet-foreman has an issue in the pick() functions in foreman::cli (at least), so I hope to disable it in as few modules as possible when syncing.