### PR TITLE
Remove some Puppet/Ruby combinations from matrix tests

### DIFF
--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -2,38 +2,25 @@
 # This file is managed centrally by modulesync
 #   https://github.com/theforeman/foreman-installer-modulesync
 rvm:
-  - 1.9.3
-  - 2.0.0
   - 2.1.5
 env:
   # First test the major distros
-  - PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64
-  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64
-  # Test operating systems with ruby 1.8.7 explicitly so we can exclude ruby 1.8.7 tests for other OS
-  - PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64
-  - PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64
+  - PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64
+  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64
   # Test the rest of the supported platforms
-  - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
-  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
+  - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64
+  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64
 matrix:
   fast_finish: true
-  exclude:
-    # No support for Ruby 1.9.3 on Puppet 4.x
-    - rvm: 1.9.3
-      env: PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64
-    - rvm: 1.9.3
-      env: PUPPET_VERSION=4.0 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64
-    - rvm: 1.9.3
-      env: PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,scientific-6-x86_64,centos-6-x86_64
   include:
-    # Only platforms left to support ruby 1.8.7
-    - rvm: 1.8.7
-      env: PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64
-    - rvm: 1.8.7
-      env: PUPPET_VERSION=3.5 ONLY_OS=ubuntu-12-x86_64,ubuntu-12.04-x86_64,redhat-6-x86_64,centos-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+    # Only Ubuntu 14.04 uses Ruby 1.9.3 to run Puppet 3.x
+    - rvm: 1.9.3
+      env: PUPPET_VERSION=3.5 ONLY_OS="ubuntu-14-x86_64,ubuntu-14.04-x86_64"
+    # Only EL7 uses Ruby 2.0.0 to run Puppet 3.x
+    - rvm: 2.0.0
+      env: PUPPET_VERSION=3.5 ONLY_OS="centos-7-x86_64"
     # Only Puppet 4.x supports Ruby 2.2. Also limit the OS set we test Ruby 2.2 with.
     - rvm: 2.2.3
       env: PUPPET_VERSION=4.0 ONLY_OS="debian-8-x86_64,centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,freebsd-10-amd64,windows-2012 R2-x64"


### PR DESCRIPTION
1.9.3 and 2.0.0 are no longer tested for each combination of OSes and
Puppet versions, and instead only run tests for Ubuntu 14.04 and EL7 on
Puppet 3.x where they're used. Tests for 1.8.7 are removed entirely.
2.1 is the main test target as it's used by Puppet AIO packages.

Ubuntu 14.04 changed to 16.04 in the major OS list, and removed the old
OS (12.04, EL6) individual line as they were being run for each Ruby
version, except 1.9.3.

Example test run on puppet-foreman: https://travis-ci.org/domcleal/puppet-foreman/builds/168542696