### PR TITLE
Add custom facts

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -7,7 +7,7 @@ Gemfile:
   - gem: rspec-puppet
     version: '~> 2.3'
   - gem: rspec-puppet-facts
-    version: '>= 1.5'
+    version: '>= 1.7'
   - gem: puppetlabs_spec_helper
     version: '>= 0.8.0'
   - gem: puppet-lint

--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -9,6 +9,10 @@ require '<%= r %>'
 require 'rspec-puppet-facts'
 include RspecPuppetFacts
 
+                                                    # Original fact sources:
+add_custom_fact :concat_basedir, '/tmp'             # puppetlabs-concat
+add_custom_fact :puppetversion, Puppet.version      # Facter, but excluded from rspec-puppet-facts
+
 # Workaround for no method in rspec-puppet to pass undef through :params
 class Undef
   def inspect; 'undef'; end


### PR DESCRIPTION
This uses the rspec-puppet-facts 1.7 feature to add custom facts. Since
we often override this in our specs this can greatly reduce duplication
in our specs.