### PR TITLE
Update Travis to run Arch tests on Puppet 4 only

### DIFF
--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -8,10 +8,10 @@ env:
   - PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64
   - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
   - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64
-  # Test the rest of the supported platforms
+  # Test the rest of the supported platforms (Arch only has 4.0+ available in its repos)
   - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64
-  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64
+  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64,archlinux-3-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64,archlinux-3-x86_64
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
Archlinux only has Puppet 4 available in it's repos, so it's not valuable to test Puppet 3 (and causes failures anyway). See discussion in the Arch support PR to puppet-puppet -> https://github.com/theforeman/puppet-puppet/pull/384#discussion_r85480140 for detail.