### PR TITLE
Exclude spec/static_fixtures/ from syntax checks on Puppet 3

### DIFF
--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -19,6 +19,9 @@ end
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "vendor/**/*.pp"]
 PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{KIND}: %{message}'
 
+# Used for type alias tests
+PuppetSyntax.exclude_paths << 'spec/static_fixtures/test_module/**/*.pp' if Puppet.version.to_f < 4.0
+
 require 'puppet-lint-param-docs/tasks'
 PuppetLintParamDocs.define_selective do |config|
   config.pattern = <%= @configs['param_docs_pattern'].inspect %>


### PR DESCRIPTION
May be used for type alias tests which require a Puppet 4 syntax.

Used in https://github.com/theforeman/puppet-foreman_proxy/pull/308