### PR TITLE
relayout test run sets

### DIFF
--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -5,13 +5,11 @@ rvm:
   - 2.1.5
 env:
   # First test the major distros
-  - PUPPET_VERSION=4.0 ONLY_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64
-  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION=3.5 ONLY_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64
-  # Test the rest of the supported platforms (Arch only has 4.0+ available in its repos)
-  - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64
-  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64,archlinux-3-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION=3.5 EXCLUDE_OS=centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64,archlinux-3-x86_64
+  - PUPPET_VERSION=4.0 ONLY_OS=centos-6-x86_64,centos-7-x86_64,debian-7-x86_64,debian-8-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64
+  - PUPPET_VERSION=3.5 ONLY_OS=debian-8-x86_64 FUTURE_PARSER=yes TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION=3.5 ONLY_OS=debian-8-x86_64
+  # Test the rest of the supported platforms
+  - PUPPET_VERSION=4.0 EXCLUDE_OS=centos-6-x86_64,centos-7-x86_64,debian-7-x86_64,debian-8-x86_64,ubuntu-14-x86_64,ubuntu-14.04-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,scientific-6-x86_64,scientific-7-x86_64
 matrix:
   fast_finish: true
   include:
@@ -20,7 +18,7 @@ matrix:
       env: PUPPET_VERSION=3.5 ONLY_OS="ubuntu-14-x86_64,ubuntu-14.04-x86_64"
     # Only EL7 uses Ruby 2.0.0 to run Puppet 3.x
     - rvm: 2.0.0
-      env: PUPPET_VERSION=3.5 ONLY_OS="centos-7-x86_64"
+      env: PUPPET_VERSION=3.5 ONLY_OS="centos-7-x86_64,redhat-7-x86_64"
     # Only Puppet 4.x supports Ruby 2.2. Also limit the OS set we test Ruby 2.2 with.
     - rvm: 2.2.3
       env: PUPPET_VERSION=4.0 ONLY_OS="debian-8-x86_64,centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,freebsd-10-amd64,windows-2012 R2-x64"


### PR DESCRIPTION
- only Debian/jessie uses Ruby2.1 with Puppet 3.x
- better divide the Ruby 2.1.5 + Puppet 4.0 run