### PR TITLE
Add Beaker tests to Travis CI config

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -49,6 +49,8 @@ Gemfile:
   default_disabled_lint_checks:
   - '140chars'
   - 'class_inherits_from_params_class'
+.travis.yml:
+  beaker_sets: []
 spec/spec_helper.rb:
   requires: []
 Rakefile:

--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -25,5 +25,16 @@ matrix:
     # Only Puppet >= 4.4 supports Ruby 2.3. Also limit the OS set we test Ruby 2.3 with.
     - rvm: 2.3.0
       env: PUPPET_VERSION=4.4 ONLY_OS="debian-8-x86_64,centos-7-x86_64,ubuntu-16-x86_64,ubuntu-16.04-x86_64,freebsd-10-amd64,windows-2012 R2-x64"
+<% if !@configs['beaker_sets'].empty? -%>
+    # Acceptance tests
+<% @configs['beaker_sets'].each do |set| -%>
+    - rvm: 2.3.1
+      dist: trusty
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=<%= set %>
+      script: bundle exec rake beaker
+      services: docker
+      bundler_args: --without development
+<% end -%>
+<% end -%>
 bundler_args: --without system_tests development
 sudo: false


### PR DESCRIPTION
Set beaker_sets per project to an array of Docker-based nodesets,
generating a new Travis CI sub-job per set.

Tests running on https://github.com/theforeman/puppet-puppet/pull/474.