### PR TITLE
Add Travis CI config to modulesync repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+---
+# This tests the modulesync configuration _itself_.
+# The config used for modules is at moduleroot/.travis.yml
+rvm: 2.3.1
+# Use anonymous, read-only interface to clone
+before_script: "echo 'git_base: https://github.com/' >> modulesync.yml"
+script: msync update -n theforeman --noop
+sudo: false


### PR DESCRIPTION
Test successful no-op execution (undefined vars etc), plus shows the
diff for all modules in the test output.