### PR TITLE
Ensure at least puppet 3.5 is used

### DIFF
--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -3,7 +3,7 @@
 
 source 'https://rubygems.org'
 
-gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 2.7'
+gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 3.5'
 
 <% (@configs['required'] + (@configs['extra'] || [])).each do |gem| -%>
 gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %><%= ", #{gem['options'].inspect}" if gem['options'] %>


### PR DESCRIPTION
It's been a while since we've supported puppet 2.7. This is unlikely to
change anything, but it formalises the reality.