### PR TITLE
Pin puppetlabs_spec_helper for Ruby 1.9.3 compat

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -9,7 +9,7 @@ Gemfile:
   - gem: rspec-puppet-facts
     version: '>= 1.7'
   - gem: puppetlabs_spec_helper
-    version: '>= 0.8.0'
+    version: '= 2.1.0'
   - gem: puppet-lint
     version: '>= 2'
   - gem: puppet-lint-unquoted_string-check


### PR DESCRIPTION
puppetlabs_spec_helper 2.1.1 started requiring parallel_tests which
requires Ruby 2.0+.