### PR TITLE
Add additional checks on resources in spec helpers

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -45,6 +45,7 @@ def on_os_under_test
 end
 
 def get_content(subject, title)
+  is_expected.to contain_file(title)
   content = subject.resource('file', title).send(:parameters)[:content]
   content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }
 end
@@ -54,12 +55,14 @@ def verify_exact_contents(subject, title, expected_lines)
 end
 
 def verify_concat_fragment_contents(subject, title, expected_lines)
+  is_expected.to contain_concat__fragment(title)
   content = subject.resource('concat::fragment', title).send(:parameters)[:content]
   expect(content.split("\n") & expected_lines).to eq(expected_lines)
 end
 
 def verify_concat_fragment_exact_contents(subject, title, expected_lines)
+  is_expected.to contain_concat__fragment(title)
   content = subject.resource('concat::fragment', title).send(:parameters)[:content]
-    expect(content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }).to eq(expected_lines)
+  expect(content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }).to eq(expected_lines)
 end
 <%= "\n" + @configs['extra_code'] if @configs['extra_code'] -%>


### PR DESCRIPTION
This changes the following error:

     Failure/Error: content = subject.resource('concat::fragment', title).send(:parameters)[:content]

     NoMethodError:
       undefined method `parameters' for nil:NilClass

into the much easier to understand:

     Failure/Error: is_expected.to contain_concat__fragment(title)
       expected that the catalogue would contain Concat::Fragment[dhcp.conf+50_includes]