### PR TITLE
Use match_array to compare arrays

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -51,18 +51,18 @@ def get_content(subject, title)
 end
 
 def verify_exact_contents(subject, title, expected_lines)
-  expect(get_content(subject, title)).to eq(expected_lines)
+  expect(get_content(subject, title)).to match_array(expected_lines)
 end
 
 def verify_concat_fragment_contents(subject, title, expected_lines)
   is_expected.to contain_concat__fragment(title)
   content = subject.resource('concat::fragment', title).send(:parameters)[:content]
-  expect(content.split("\n") & expected_lines).to eq(expected_lines)
+  expect(content.split("\n") & expected_lines).to match_array(expected_lines)
 end
 
 def verify_concat_fragment_exact_contents(subject, title, expected_lines)
   is_expected.to contain_concat__fragment(title)
   content = subject.resource('concat::fragment', title).send(:parameters)[:content]
-  expect(content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }).to eq(expected_lines)
+  expect(content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }).to match_array(expected_lines)
 end
 <%= "\n" + @configs['extra_code'] if @configs['extra_code'] -%>


### PR DESCRIPTION
This changes the rather useless output of:

       expected: ["jpa.config.hibernate.dialect=org.hibernate.dialect.MySQLDialect", "jpa.config.hibernate.connection...., "org.quartz.dataSource.myDS.password=testpassword", "org.quartz.dataSource.myDS.maxConnections=5"]
            got: ["jpa.config.hibernate.dialect=org.hibernate.dialect.MySQLDialect", "jpa.config.hibernate.connection...., "org.quartz.dataSource.myDS.password=testpassword", "org.quartz.dataSource.myDS.maxConnections=5"]

to the useful output:

       expected collection contained:  ["jpa.config.hibernate.connection.driver_class=com.mysql.jdbc.Driver", "jpa.config.hibernate.connecti...hreshold=60000", "org.quartz.jobStore.tablePrefix=QRTZ_", "org.quartz.jobStore.useProperties=false"]
       actual collection contained:    ["jpa.config.hibernate.connection.driver_class=com.mysql.jdbc.Driver", "jpa.config.hibernate.connecti...hreshold=60000", "org.quartz.jobStore.tablePrefix=QRTZ_", "org.quartz.jobStore.useProperties=false"]
       the missing elements were:      ["org.quartz.dataSource.myDS.driver=org.hibernate.dialect.MySQLDialect"]
       the extra elements were:        ["org.quartz.dataSource.myDS.driver=com.mysql.jdbc.Driver"]