### PR TITLE
Add vagrant_libvirt Beaker nodesets

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/vagrant_libvirt/centos-6.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/vagrant_libvirt/centos-6.yml.erb
@@ -1,0 +1,15 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/theforeman/foreman-installer-modulesync
+HOSTS:
+  centos-6-x64:
+    platform: centos-6-x86_64
+    box: centos/6
+    hypervisor: vagrant_libvirt
+    vagrant_memsize: 3072
+CONFIG:
+  trace_limit: 200
+  masterless: true
+...
+# vim: syntax=yaml

--- a/moduleroot/spec/acceptance/nodesets/vagrant_libvirt/centos-7.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/vagrant_libvirt/centos-7.yml.erb
@@ -1,0 +1,15 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/theforeman/foreman-installer-modulesync
+HOSTS:
+  centos-7-x64:
+    platform: centos-7-x86_64
+    box: centos/7
+    hypervisor: vagrant_libvirt
+    vagrant_memsize: 3072
+CONFIG:
+  trace_limit: 200
+  masterless: true
+...
+# vim: syntax=yaml

--- a/moduleroot/spec/acceptance/nodesets/vagrant_libvirt/debian-8.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/vagrant_libvirt/debian-8.yml.erb
@@ -1,0 +1,15 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/theforeman/foreman-installer-modulesync
+HOSTS:
+  debian-8-x64:
+    platform: debian-8-x86_64
+    box: debian/jessie64
+    hypervisor: vagrant_libvirt
+    vagrant_memsize: 3072
+CONFIG:
+  trace_limit: 200
+  masterless: true
+...
+# vim: syntax=yaml

--- a/moduleroot/spec/acceptance/nodesets/vagrant_libvirt/debian-9.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/vagrant_libvirt/debian-9.yml.erb
@@ -1,0 +1,15 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/theforeman/foreman-installer-modulesync
+HOSTS:
+  debian-9-x64:
+    platform: debian-9-x86_64
+    box: debian/stretch64
+    hypervisor: vagrant_libvirt
+    vagrant_memsize: 3072
+CONFIG:
+  trace_limit: 200
+  masterless: true
+...
+# vim: syntax=yaml


### PR DESCRIPTION
Makes it easy to run acceptance tests with pre-provided configs using vagrant-libvirt. Ubuntu configs are missing as there aren't any official libvirt boxes on Atlas.