### PR TITLE
Revert "add FACTER_VERSION and 2.4.x as default (#66)"

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -4,7 +4,6 @@
 source 'https://rubygems.org'
 
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 4.6'
-gem 'facter', ENV.key?('FACTER_VERSION') ? "~> #{ENV['FACTER_VERSION']}" : '~> 2.4.6'
 
 <% (@configs['required'] + (@configs['extra'] || [])).each do |gem| -%>
 gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %><%= ", #{gem['options'].inspect}" if gem['options'] %>


### PR DESCRIPTION
This reverts commit 9de257a52fa057d81facba5289dfa829d585341f. puppetdb includes facts for facter 2.5 now so there is no reason to pin this.