### PR TITLE
Use beaker-module_install_helper

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -54,6 +54,10 @@ Gemfile:
     options:
       groups:
         - 'system_tests'
+  - gem: 'beaker-module_install_helper'
+    options:
+      groups:
+        - 'system_tests'
   - gem: 'beaker-puppet_install_helper'
     options:
       groups:
@@ -71,6 +75,7 @@ Gemfile:
 spec/spec_helper.rb:
   requires: []
 spec/spec_helper_acceptance.rb:
-  modules: ['puppetlabs-stdlib']
+  modules: []
+  install_epel: false
 Rakefile:
   param_docs_pattern: []

--- a/moduleroot/spec/spec_helper_acceptance.rb.erb
+++ b/moduleroot/spec/spec_helper_acceptance.rb.erb
@@ -1,31 +1,36 @@
 require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 require 'beaker/puppet_install_helper'
+require 'beaker/module_install_helper'
 
 run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
+install_module_on(hosts)
+install_module_dependencies_on(hosts)
 
 RSpec.configure do |c|
-  # Project root
-  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-
   # Readable test descriptions
   c.formatter = :documentation
 
   # Configure all nodes in nodeset
   c.before :suite do
     # Install module and dependencies
-    puppet_module_install(:source => proj_root, :module_name => '<%= @configs[:puppet_module].split('-').last %>')
     hosts.each do |host|
+      <%- if @configs['modules'].any? -%>
       <%= @configs['modules'].inspect %>.each do |mod|
-        on host, puppet('module', 'install', mod), { :acceptable_exit_codes => [0] }
+        install_module_from_forge(mod, '>= 0')
       end
 
+      <%- end -%>
       if fact_on(host, 'osfamily') == 'RedHat'
         # don't delete downloaded rpm for use with BEAKER_provision=no +
         # BEAKER_destroy=no
         on host, 'sed -i "s/keepcache=.*/keepcache=1/" /etc/yum.conf'
         # refresh check if cache needs refresh on next yum command
         on host, 'yum clean expire-cache'
+        <%- if @configs['install_epel'] -%>
+        # We always need EPEL
+        on host, puppet('resource', 'package', 'epel-release', 'ensure=installed')
+        <%- end -%>
       end
     end
   end
@@ -39,4 +44,13 @@ shared_examples 'a idempotent resource' do
   it 'applies a second time without changes' do
     apply_manifest(pp, catch_changes: true)
   end
+end
+
+shared_examples 'the example' do |name|
+  let(:pp) do
+    path = File.join(File.dirname(File.dirname(__FILE__)), 'examples', name)
+    File.read(path)
+  end
+
+  include_examples 'a idempotent resource'
 end


### PR DESCRIPTION
Copies the Katello's modulesync but installing EPEL is optional. This will need changes in modules .sync.yml since the modules variable is re-used which I'll do if this is merged.