### PR TITLE
Use .pmtignore

### DIFF
--- a/moduleroot/.pmtignore.erb
+++ b/moduleroot/.pmtignore.erb
@@ -43,6 +43,12 @@ coverage/
 ## Beaker
 .vagrant/
 log/
+
+# Files we don't want to ship in a release
+CONTRIBUTING.md
+Gemfile
+Rakefile
+spec/
 <% if ! @configs['paths'].nil? -%>
 
 # Module-specific paths


### PR DESCRIPTION
This allows us to exclude tests and other files that make no sense in a shipped module. This should result in smaller modules and less cruft in the installer.