### PR TITLE
Use FQDNs as docker names

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/docker/centos-6.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/docker/centos-6.yml.erb
@@ -3,7 +3,7 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/theforeman/foreman-installer-modulesync
 HOSTS:
-  centos-6-x64:
+  centos-6-x64.example.com:
     platform: el-6-x86_64
     hypervisor: docker
     image: centos:6

--- a/moduleroot/spec/acceptance/nodesets/docker/centos-7.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/docker/centos-7.yml.erb
@@ -3,7 +3,7 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/theforeman/foreman-installer-modulesync
 HOSTS:
-  centos-7-x64:
+  centos-7-x64.example.com:
     platform: el-7-x86_64
     hypervisor: docker
     image: centos:7

--- a/moduleroot/spec/acceptance/nodesets/docker/debian-8.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/docker/debian-8.yml.erb
@@ -3,7 +3,7 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/theforeman/foreman-installer-modulesync
 HOSTS:
-  debian-8-x64:
+  debian-8-x64.example.com:
     platform: debian-8-amd64
     hypervisor: docker
     image: debian:8

--- a/moduleroot/spec/acceptance/nodesets/docker/debian-9.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/docker/debian-9.yml.erb
@@ -3,7 +3,7 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/theforeman/foreman-installer-modulesync
 HOSTS:
-  debian-9-x64:
+  debian-9-x64.example.com:
     platform: debian-9-amd64
     hypervisor: docker
     image: debian:9

--- a/moduleroot/spec/acceptance/nodesets/docker/ubuntu-14.04.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/docker/ubuntu-14.04.yml.erb
@@ -3,7 +3,7 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/theforeman/foreman-installer-modulesync
 HOSTS:
-  ubuntu-1404-x64:
+  ubuntu-1404-x64.example.com:
     platform: ubuntu-14.04-amd64
     hypervisor: docker
     image: ubuntu:14.04

--- a/moduleroot/spec/acceptance/nodesets/docker/ubuntu-16.04.yml.erb
+++ b/moduleroot/spec/acceptance/nodesets/docker/ubuntu-16.04.yml.erb
@@ -3,7 +3,7 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/theforeman/foreman-installer-modulesync
 HOSTS:
-  ubuntu-1604-x64:
+  ubuntu-1604-x64.example.com:
     platform: ubuntu-16.04-amd64
     hypervisor: docker
     image: ubuntu:16.04


### PR DESCRIPTION
By using short names you will end up with the following hosts file:

    192.168.122.100 centos-7-x64
    127.0.0.1 localhost
    192.168.122.100 centos-7-x64.example.com

The result is that facter fqdn returns centos-7-x64.example.com where
hostname -f returns centos-7-x64. This breaks some scripts with pulp.