### PR TITLE
Update travis config

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -59,6 +59,7 @@ Gemfile:
   - 'class_inherits_from_params_class'
 .travis.yml:
   beaker_sets: []
+  test_all_rvms: true
 spec/spec_helper.rb:
   requires: []
 spec/spec_helper_acceptance.rb:

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -2,11 +2,13 @@
 # This file is managed centrally by modulesync
 #   https://github.com/theforeman/foreman-installer-modulesync
 rvm:
-  - 2.1.5
+  - 2.1.9
+<% if @configs['test_all_rvms'] -%>
   - 2.2.6
   - 2.3.0
   - 2.4.1
 
+<% end -%>
 env:
 <% if @configs['env'] && @configs['env']['global'] -%>
   global:
@@ -21,7 +23,7 @@ matrix:
   include:
     - rvm: 2.4.1
       env: PUPPET_VERSION=5.0
-<% if !@configs['beaker_sets'].empty? -%>
+<% unless @configs['beaker_sets'].empty? -%>
     # Acceptance tests
 <% @configs['beaker_sets'].each do |set| -%>
     - rvm: 2.3.1


### PR DESCRIPTION
This allows disabling running under all RVMs. Because Katello only
supports running in AIO this lowers the load on Travis. It also updates
the RVM to 2.1.9 because that's included in the Puppet 4 AIO.