### PR TITLE
Add custom facts

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -9,9 +9,11 @@ require '<%= r %>'
 require 'rspec-puppet-facts'
 include RspecPuppetFacts
 
-                                                    # Original fact sources:
-add_custom_fact :concat_basedir, '/tmp'             # puppetlabs-concat
-add_custom_fact :puppetversion, Puppet.version      # Facter, but excluded from rspec-puppet-facts
+                                                                             # Original fact sources:
+add_custom_fact :concat_basedir, '/tmp'                                      # puppetlabs-concat
+add_custom_fact :puppetversion, Puppet.version                               # Facter, but excluded from rspec-puppet-facts
+add_custom_fact :puppet_environmentpath, '/etc/puppetlabs/code/environments' # puppetlabs-stdlib
+add_custom_fact :root_home, '/root'                                          # puppetlabs-stdlib
 
 # Workaround for no method in rspec-puppet to pass undef through :params
 class Undef


### PR DESCRIPTION
puppet_environmentpath is also used in puppet-foreman_proxy but locally
overridden. root_home is used in puppet-mongodb which puppet-pulp uses.
Since they're provided by puppetlabs-stdlib we can rely on them existing
in all modules.