### PR TITLE
Fix Katello changelogs & allow custom facts to be set

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -79,6 +79,7 @@ Gemfile:
   beaker_puppet_collection: puppet5
 spec/spec_helper.rb:
   requires: []
+  custom_facts: []
 spec/spec_helper_acceptance.rb:
   modules: []
   install_epel: false

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -32,7 +32,7 @@ begin
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?
     metadata = JSON.load(File.read('metadata.json'))
-    config.user = metadata['author']
+    config.user = 'theforeman'
     config.project = "puppet-#{metadata['name'].split('-').last}"
     config.future_release = metadata['version']
     config.exclude_labels = ['duplicate', 'question', 'invalid', 'wontfix', 'Modulesync', 'skip-changelog']

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -10,7 +10,6 @@ require 'rspec-puppet-facts'
 include RspecPuppetFacts
 
                                                                              # Original fact sources:
-add_custom_fact :concat_basedir, '/tmp'                                      # puppetlabs-concat
 add_custom_fact :puppet_environmentpath, '/etc/puppetlabs/code/environments' # puppetlabs-stdlib
 add_custom_fact :root_home, '/root'                                          # puppetlabs-stdlib
 <% @configs['custom_facts'].each do |fact| -%>

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -13,6 +13,9 @@ include RspecPuppetFacts
 add_custom_fact :concat_basedir, '/tmp'                                      # puppetlabs-concat
 add_custom_fact :puppet_environmentpath, '/etc/puppetlabs/code/environments' # puppetlabs-stdlib
 add_custom_fact :root_home, '/root'                                          # puppetlabs-stdlib
+<% @configs['custom_facts'].each do |fact| -%>
+add_custom_fact :<%= fact['name'] %>, <%= fact['value'].inspect %> # <%= fact['source'] %>
+<% end -%>
 
 # Workaround for no method in rspec-puppet to pass undef through :params
 class Undef


### PR DESCRIPTION
* [x] https://github.com/theforeman/puppet-candlepin/pull/105
* [ ] https://github.com/theforeman/puppet-certs/pull/209
* [x] https://github.com/theforeman/puppet-dhcp/pull/132
* [x] https://github.com/theforeman/puppet-dns/pull/120
* [x] https://github.com/theforeman/puppet-foreman/pull/658
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/442
* [x] https://github.com/theforeman/puppet-foreman_proxy_content/pull/173
* [x] https://github.com/theforeman/puppet-git/pull/43
* [x] https://github.com/theforeman/puppet-katello/pull/250
* [x] https://github.com/theforeman/puppet-katello_devel/pull/169
* [x] https://github.com/theforeman/puppet-pulp/pull/332
* [x] https://github.com/theforeman/puppet-puppet/pull/614
* [x] https://github.com/theforeman/puppet-qpid/pull/99
* [x] https://github.com/theforeman/puppet-tftp/pull/76