### PR TITLE
Sync local module changes

### DIFF
--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -45,6 +45,10 @@ matrix:
       script: bundle exec rake beaker
       services: docker
       bundler_args: --without development
+      before_install:
+        - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
+        - sudo service docker restart
+
 <% end -%>
 <% end -%>
 <% end -%>

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -1,6 +1,10 @@
 # This file is managed centrally by modulesync
 #   https://github.com/theforeman/foreman-installer-modulesync
 
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
+
 require 'puppetlabs_spec_helper/module_spec_helper'
 <% (@configs['requires'] || []).each do |r| -%>
 require '<%= r %>'

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -72,4 +72,5 @@ def verify_concat_fragment_exact_contents(subject, title, expected_lines)
   content = subject.resource('concat::fragment', title).send(:parameters)[:content]
   expect(content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }).to match_array(expected_lines)
 end
-<%= "\n" + @configs['extra_code'] if @configs['extra_code'] -%>
+
+Dir["./spec/support/**/*.rb"].sort.each { |f| require f }

--- a/moduleroot/spec/spec_helper_acceptance.rb.erb
+++ b/moduleroot/spec/spec_helper_acceptance.rb.erb
@@ -61,3 +61,5 @@ shared_examples 'the example' do |name|
 
   include_examples 'a idempotent resource'
 end
+
+Dir["./spec/support/acceptance/**/*.rb"].sort.each { |f| require f }


### PR DESCRIPTION
Various modules had local changes and this brings them all back to a central state.

* [x] https://github.com/theforeman/puppet-candlepin/pull/125
* [x] https://github.com/theforeman/puppet-certs/pull/235
* [x] https://github.com/theforeman/puppet-dhcp/pull/142
* [x] https://github.com/theforeman/puppet-dns/pull/132
* [x] https://github.com/theforeman/puppet-foreman/pull/703
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/473
* [x] https://github.com/theforeman/puppet-foreman_proxy_content/pull/187
* [x] https://github.com/theforeman/puppet-git/pull/52
* [x] https://github.com/theforeman/puppet-katello/pull/274
* [x] https://github.com/theforeman/puppet-katello_devel/pull/186
* [x] https://github.com/theforeman/puppet-pulp/pull/352
* [x] https://github.com/theforeman/puppet-puppet/pull/658
* [x] https://github.com/theforeman/puppet-qpid/pull/109
* [x] https://github.com/theforeman/puppet-tftp/pull/87