### PR TITLE
Ensure bundler 1.17.3 is used on Ruby 2.1.9

### DIFF
--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -53,4 +53,8 @@ matrix:
 <% end -%>
 <% end -%>
 bundler_args: --without system_tests development
+before_install:
+  - if [ $TRAVIS_RUBY_VERSION = 2.1.9 ] ; then
+      gem install -v 1.17.3 bundler --no-rdoc --no-ri;
+    fi
 sudo: false


### PR DESCRIPTION
* [x] https://github.com/theforeman/puppet-candlepin/pull/126
* [x] https://github.com/theforeman/puppet-certs/pull/237
* [x] https://github.com/theforeman/puppet-dhcp/pull/145
* [x] https://github.com/theforeman/puppet-dns/pull/134
* [x] https://github.com/theforeman/puppet-foreman/pull/704
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/474
* [x] https://github.com/theforeman/puppet-foreman_proxy_content/pull/188
* [x] https://github.com/theforeman/puppet-git/pull/54
* [x] https://github.com/theforeman/puppet-katello/pull/275
* [x] https://github.com/theforeman/puppet-katello_devel/pull/188
* [x] https://github.com/theforeman/puppet-pulp/pull/353
* [x] https://github.com/theforeman/puppet-puppet/pull/666
* [x] https://github.com/theforeman/puppet-qpid/pull/111
* [x] https://github.com/theforeman/puppet-tftp/pull/89