### PR TITLE
Stop installing Puppet 5 for changelogs

### DIFF
--- a/bin/changelogs
+++ b/bin/changelogs
@@ -15,7 +15,6 @@ CONCURRENT_GIT = 5
 CONCURRENT_BUNDLER = 5
 BUNDLER_JOBS = 5
 BUNDLER_RETRY = 5
-PUPPET_VERSION = '5.0'
 
 
 async def check_output(cmd: typing.Sequence[str], path: os.PathLike, env=None) -> str:
@@ -71,9 +70,8 @@ async def update_checkout(module: Path, semaphore: asyncio.Semaphore) -> None:
 
 async def bundle_update(module: Path, semaphore: asyncio.Semaphore) -> None:
     cmd = ['bundle', 'update', '--jobs', str(BUNDLER_JOBS), '--retry', str(BUNDLER_RETRY)]
-    env = {'PUPPET_VERSION': PUPPET_VERSION}
     async with semaphore:
-        await check_output(cmd, env=env, path=module)
+        await check_output(cmd, path=module)
 
 
 async def generate_changelog(module: Path, token: str, semaphore: asyncio.Semaphore) -> str:

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -17,7 +17,7 @@ Gemfile:
       groups:
       - 'development'
   - gem: puppet-blacksmith
-    version: '>= 4.1.0'
+    version: '>= 6.0.0'
     options:
       groups:
       - 'development'


### PR DESCRIPTION
Puppet 6 removes the puppet module build face and moved it into the PDK.  With puppet-blacksmith 6.0.0, it can build modules on Puppet 6 without the PDK by using puppet-modulebuilder. This makes it compatible with our modules.