### PR TITLE
Use fixtures in acceptance tests

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -22,7 +22,7 @@ Gemfile:
       groups:
       - 'development'
   - gem: 'voxpupuli-acceptance'
-    version: '~> 0.1'
+    version: '~> 0.2'
     options:
       groups:
         - 'system_tests'

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -3,6 +3,9 @@
 
 require 'voxpupuli/test/rake'
 
+# We use fixtures in our modules, which is not the default
+task :beaker => 'spec_prep'
+
 # blacksmith isn't always present, e.g. on Travis with --without development
 begin
   require 'puppet_blacksmith/rake_tasks'

--- a/moduleroot/spec/spec_helper_acceptance.rb.erb
+++ b/moduleroot/spec/spec_helper_acceptance.rb.erb
@@ -2,7 +2,7 @@ require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 ENV['BEAKER_setfile'] ||= 'centos7-64{hostname=centos7-64.example.com}'
 
-configure_beaker do |host|
+configure_beaker(modules: :fixtures) do |host|
   if fact_on(host, 'os.family') == 'RedHat'
     unless fact_on(host, 'os.name') == 'Fedora'
       # don't delete downloaded rpm for use with BEAKER_provision=no +


### PR DESCRIPTION
voxpupuli-acceptance 0.2 introduces the option to install Puppet modules based on fixtures rather than metadata.json. This is much faster and allows using git checkouts.