### PR TITLE
Automatically generate beaker sets from metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 ---
 # This tests the modulesync configuration _itself_.
 # The config used for modules is at moduleroot/.travis.yml
-rvm: 2.3.1
+dist: bionic
+rvm: 2.6
 # Use anonymous, read-only interface to clone
 before_script: "echo 'git_base: https://github.com/' >> modulesync.yml"
 script: msync update -n theforeman --noop
-sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'modulesync', '~> 1.0'
+gem 'modulesync', '~> 1.1'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'modulesync', '~> 0.8'
+gem 'modulesync', '~> 1.0'

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ README](https://github.com/puppetlabs/modulesync).
 Generate a changelog
 
 ```console
-$ ./bin/changelogs modules/puppet-foreman
-Updated /path/to/foreman-installer-modulesync/modules/puppet-foreman/CHANGELOG.md
+$ ./bin/changelogs modules/theforeman/puppet-foreman
+Updated /path/to/foreman-installer-modulesync/modules/theforeman/puppet-foreman/CHANGELOG.md
 ```
 
 Inspect the changelog, (re)label any PRs and issues if needed. Also decide whether a version bump is needed.
 
 ```console
-$ cd modules/puppet-foreman
+$ cd modules/theforeman/puppet-foreman
 $ bundle exec rake module:bump:minor
 Bumping version from 13.0.1 to 13.1.0
 ```
@@ -31,7 +31,7 @@ Regenerate the changelog while leaving any git changes:
 
 ```console
 $ ../../bin/changelogs --skip-git .
-Updated /path/to/foreman-installer-modulesync/modules/puppet-foreman/CHANGELOG.md
+Updated /path/to/foreman-installer-modulesync/modules/theforeman/puppet-foreman/CHANGELOG.md
 ```
 
 Now send a PR for the release:
@@ -57,9 +57,9 @@ $ ../../bin/release-module
 This repository also contains scripts to easy module releases. This short workflow:
 
 ```console
-$ ./bin/tiers --tier 0 modules/puppet-*/metadata.json | awk '{ print $2 }' | xargs ./bin/changelogs
-Updated /path/to/foreman-installer-modulesync/modules/puppet-git/CHANGELOG.md
-Updated /path/to/foreman-installer-modulesync/modules/puppet-dhcp/CHANGELOG.md
+$ ./bin/tiers --tier 0 modules/theforeman/puppet-*/metadata.json | awk '{ print $2 }' | xargs ./bin/changelogs
+Updated /path/to/foreman-installer-modulesync/modules/theforeman/puppet-git/CHANGELOG.md
+Updated /path/to/foreman-installer-modulesync/modules/theforeman/puppet-dhcp/CHANGELOG.md
 ...
 ```
 
@@ -70,25 +70,25 @@ Go over every changelog module per the Short Single Release Workflow. Once tier 
 To find the order in which to release, tiers can be used:
 
 ```console
-$ ./bin/tiers modules/puppet-*/metadata.json
+$ ./bin/tiers modules/theforeman/puppet-*/metadata.json
 Tier 0
-  katello/certs	modules/puppet-certs
-  katello/qpid	modules/puppet-qpid
-  theforeman/dhcp	modules/puppet-dhcp
-  theforeman/dns	modules/puppet-dns
-  theforeman/foreman	modules/puppet-foreman
-  theforeman/git	modules/puppet-git
-  theforeman/puppet	modules/puppet-puppet
-  theforeman/tftp	modules/puppet-tftp
+  katello/certs	modules/theforeman/puppet-certs
+  katello/qpid	modules/theforeman/puppet-qpid
+  theforeman/dhcp	modules/theforeman/puppet-dhcp
+  theforeman/dns	modules/theforeman/puppet-dns
+  theforeman/foreman	modules/theforeman/puppet-foreman
+  theforeman/git	modules/theforeman/puppet-git
+  theforeman/puppet	modules/theforeman/puppet-puppet
+  theforeman/tftp	modules/theforeman/puppet-tftp
 Tier 1
-  katello/candlepin	modules/puppet-candlepin
-  katello/pulp	modules/puppet-pulp
-  theforeman/foreman_proxy	modules/puppet-foreman_proxy
+  katello/candlepin	modules/theforeman/puppet-candlepin
+  katello/pulp	modules/theforeman/puppet-pulp
+  theforeman/foreman_proxy	modules/theforeman/puppet-foreman_proxy
 Tier 2
-  katello/foreman_proxy_content	modules/puppet-foreman_proxy_content
-  katello/katello	modules/puppet-katello
+  katello/foreman_proxy_content	modules/theforeman/puppet-foreman_proxy_content
+  katello/katello	modules/theforeman/puppet-katello
 Tier 3
-  katello/katello_devel	modules/puppet-katello_devel
+  katello/katello_devel	modules/theforeman/puppet-katello_devel
 ```
 
 Modules from tier 0 only depend on Puppet itself and external dependencies (maintained by other organizations). Tier 1 depends on tier 0 and so on.

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -31,10 +31,10 @@ Gemfile:
   - '140chars'
   - 'class_inherits_from_params_class'
 .travis.yml:
-  beaker_sets: []
   beaker_puppet_collections:
     - puppet5
     - puppet6
+  pidfile_workaround: false
 spec/spec_helper.rb:
   requires: []
   custom_facts: []

--- a/metadata2beaker.rb
+++ b/metadata2beaker.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+require 'json'
+
+def metadata2beaker(module_path, pidfile: false, use_fqdn: true)
+  metadata = JSON.parse(File.read(File.join(module_path, 'metadata.json')))
+
+  operatingsystems = Hash[metadata['operatingsystem_support'].map { |os| [os['operatingsystem'], os['operatingsystemrelease']] }]
+
+  operatingsystems.sort.each do |os, releases|
+    next unless ['CentOS', 'Fedora', 'Debian', 'Ubuntu'].include?(os)
+    releases.each do |release|
+      name = "#{os.downcase}#{release.tr('.', '')}-64"
+
+      options = {}
+      options[:hostname] = "#{name}.example.com" if use_fqdn
+      # Docker messes up cgroups and modern systemd can't deal with that when
+      # PIDFile is used.
+      if pidfile
+        case os
+        when 'CentOS'
+          options[:image] = 'centos:7.6.1810' if release == '7'
+        when 'Ubuntu'
+          options[:image] = 'ubuntu:xenial-20191212' if release == '16.04'
+        end
+      end
+
+      setfile = name
+      setfile += "{#{options.map { |key, value| "#{key}=#{value}" }.join(',')}}" if options
+      yield setfile
+    end
+  end
+end
+
+if __FILE__ == $0
+  ARGV.each do |module_path|
+    puts "Setfiles for #{module_path}"
+    metadata2beaker(module_path) do |setfile|
+      puts "  #{setfile}"
+    end
+  end
+end

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -15,14 +15,15 @@ matrix:
       env: PUPPET_VERSION=5.0
     - rvm: 2.5.1
       env: PUPPET_VERSION=6.0
-<% unless @configs['beaker_sets'].empty? -%>
+<% if Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '*.rb')].any? -%>
     # Acceptance tests
-<% @configs['beaker_sets'].each do |set| -%>
+<% require_relative '../metadata2beaker' -%>
+<% metadata2beaker(@metadata[:workdir], pidfile: @configs['pidfile_workaround']) do |setfile| -%>
 <% @configs['beaker_puppet_collections'].each do |collection| -%>
     - rvm: 2.5.1
       env:
         - BEAKER_PUPPET_COLLECTION=<%= collection %>
-        - BEAKER_setfile=<%= set %>{hostname=<%= set %>.example.com}
+        - BEAKER_setfile=<%= setfile %>
       script: bundle exec rake beaker
       services: docker
       bundler_args: --without development


### PR DESCRIPTION
Modulesync 1.1 allows reading the metadata which makes it easy to read files in the directory. This allows generating the beaker sets automatically based on metadata.json.

Currently 1.1 is unreleased to this is a draft: https://github.com/voxpupuli/modulesync/pull/174