### PR TITLE
Require voxpupuli-test 1.4 for Debian 10 facts

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -10,7 +10,7 @@ Gemfile:
   - gem: puppet-lint-strict_indent-check
   - gem: puppet-lint-undef_in_function-check
   - gem: voxpupuli-test
-    version: '~> 1.3'
+    version: '~> 1.4'
   - gem: github_changelog_generator
     version: '>= 1.15.0'
     options:


### PR DESCRIPTION
* [x] https://github.com/theforeman/puppet-candlepin/pull/154
* [x] https://github.com/theforeman/puppet-certs/pull/283
* [x] https://github.com/theforeman/puppet-dhcp/pull/174
* [x] https://github.com/theforeman/puppet-dns/pull/165
* [x] https://github.com/theforeman/puppet-foreman/pull/836
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/589
* [x] https://github.com/theforeman/puppet-foreman_proxy_content/pull/253
* [x] https://github.com/theforeman/puppet-git/pull/66
* [x] https://github.com/theforeman/puppet-katello/pull/338
* [x] https://github.com/theforeman/puppet-katello_devel/pull/237
* [x] https://github.com/theforeman/puppet-pulp/pull/398
* [x] https://github.com/theforeman/puppet-pulpcore/pull/92
* [x] https://github.com/theforeman/puppet-puppet/pull/740
* [x] https://github.com/theforeman/puppet-puppetserver_foreman/pull/2
* [x] https://github.com/theforeman/puppet-qpid/pull/133
* [x] https://github.com/theforeman/puppet-tftp/pull/106