### PR TITLE
Add skip-changelog label to release PRs

### DIFF
--- a/bin/release-pr
+++ b/bin/release-pr
@@ -21,4 +21,4 @@ fi
 git commit --message "Release $VERSION"
 
 addfork || true
-git phr --message "Release $VERSION" --base "$TARGET_BRANCH"
+git phr --message "Release $VERSION" --base "$TARGET_BRANCH" --labels skip-changelog

--- a/bin/release-pr
+++ b/bin/release-pr
@@ -13,12 +13,12 @@ fi
 
 VERSION="$(bundle exec rake module:version)"
 
-git checkout -b "release-$VERSION"
+git checkout --branch "release-$VERSION"
 git add CHANGELOG.md metadata.json
 if [[ -f HISTORY.md ]] ; then
 	git add HISTORY.md
 fi
-git commit -m "Release $VERSION"
+git commit --message "Release $VERSION"
 
 addfork || true
-git phr -m "Release $VERSION" -b "$TARGET_BRANCH"
+git phr --message "Release $VERSION" --base "$TARGET_BRANCH"


### PR DESCRIPTION
In our process we never include the release PRs themselves in changelogs and apply this label. Since hub can do this automatically, it simplifies the release process.