### PR TITLE
Add excludes for acceptance tests

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -54,8 +54,10 @@ Gemfile:
 .travis.yml:
   delete: true
 .github/workflows/acceptance.yml:
+  excludes: []
   pidfile_workaround: false
 .github/workflows/cron.yml:
+  excludes: []
   pidfile_workaround: false
 spec/spec_helper.rb:
   requires: []

--- a/moduleroot/.github/workflows/acceptance.yml.erb
+++ b/moduleroot/.github/workflows/acceptance.yml.erb
@@ -40,6 +40,14 @@ jobs:
         puppet:
           - "6"
           - "5"
+        <%- if @configs['excludes'].any? -%>
+        exclude:
+        <%- @configs['excludes'].each do |exclude| -%>
+        <%- exclude.each do |key, value| -%>
+          <%= key == exclude.first.first ? '-' : ' ' %> <%= key %>: "<%= value %>"
+        <%- end -%>
+        <%- end -%>
+        <%- end -%>
     name: Puppet ${{ matrix.puppet }} - ${{ matrix.setfile }}
     steps:
       - name: Enable IPv6 on docker

--- a/moduleroot/.github/workflows/cron.yml.erb
+++ b/moduleroot/.github/workflows/cron.yml.erb
@@ -89,6 +89,14 @@ jobs:
         puppet:
           - "6"
           - "5"
+        <%- if @configs['excludes'].any? -%>
+        exclude:
+        <%- @configs['excludes'].each do |exclude| -%>
+        <%- exclude.each do |key, value| -%>
+          <%= key == exclude.first.first ? '-' : ' ' %> <%= key %>: "<%= value %>"
+        <%- end -%>
+        <%- end -%>
+        <%- end -%>
     name: Puppet ${{ matrix.puppet }} - ${{ matrix.setfile }}
     steps:
       - name: Enable IPv6 on docker


### PR DESCRIPTION
This is a very complicated way to exclude combinations. For example:

```yaml
excludes:
  - setfile: debian10-64{hostname=debian10-64.example.com}
    puppet: "5"
  - setfile: ubuntu2004-64{hostname=ubuntu2004-64.example.com}
    puppet: "5"
```

* [x] https://github.com/theforeman/puppet-dhcp/pull/182
* [x] https://github.com/theforeman/puppet-puppet/pull/775