### PR TITLE
Allow specification of beaker facts

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -43,7 +43,7 @@ Gemfile:
       groups:
       - 'development'
   - gem: 'voxpupuli-acceptance'
-    version: '~> 0.2'
+    version: '~> 0.3'
     options:
       groups:
         - 'system_tests'
@@ -54,9 +54,11 @@ Gemfile:
 .travis.yml:
   delete: true
 .github/workflows/acceptance.yml:
+  beaker_fact_matrix: {}
   excludes: []
   pidfile_workaround: false
 .github/workflows/cron.yml:
+  beaker_fact_matrix: {}
   excludes: []
   pidfile_workaround: false
 spec/spec_helper.rb:

--- a/moduleroot/.github/workflows/acceptance.yml.erb
+++ b/moduleroot/.github/workflows/acceptance.yml.erb
@@ -43,8 +43,8 @@ jobs:
         <%- if @configs['excludes'].any? -%>
         exclude:
         <%- @configs['excludes'].each do |exclude| -%>
-        <%- exclude.each do |key, value| -%>
-          <%= key == exclude.first.first ? '-' : ' ' %> <%= key %>: "<%= value %>"
+        <%- exclude.each_with_index do |(key, value), index| -%>
+          <%= index == 0 ? '-' : ' ' %> <%= key %>: "<%= value %>"
         <%- end -%>
         <%- end -%>
         <%- end -%>

--- a/moduleroot/.github/workflows/acceptance.yml.erb
+++ b/moduleroot/.github/workflows/acceptance.yml.erb
@@ -40,6 +40,12 @@ jobs:
         puppet:
           - "6"
           - "5"
+        <%- @configs['beaker_fact_matrix'].each do |option, values| -%>
+        <%= option %>:
+        <%- values.each do |value| -%>
+          - "<%= value %>"
+        <%- end -%>
+        <%- end -%>
         <%- if @configs['excludes'].any? -%>
         exclude:
         <%- @configs['excludes'].each do |exclude| -%>
@@ -48,7 +54,13 @@ jobs:
         <%- end -%>
         <%- end -%>
         <%- end -%>
-    name: Puppet ${{ matrix.puppet }} - ${{ matrix.setfile }}
+    <%-
+      name = ['Puppet ${{ matrix.puppet }}', '${{ matrix.setfile }}']
+      @configs['beaker_fact_matrix'].each_key do |option|
+        name << "#{option.tr('_', ' ').capitalize} ${{ matrix.#{option} }}"
+      end
+    -%>
+    name: <%= name.join(' - ') %>
     steps:
       - name: Enable IPv6 on docker
         run: |
@@ -76,6 +88,9 @@ jobs:
         env:
           BEAKER_PUPPET_COLLECTION: puppet${{ matrix.puppet }}
           BEAKER_setfile: ${{ matrix.setfile }}
+          <%- @configs['beaker_fact_matrix'].keys.each do |fact| -%>
+          BEAKER_FACTER_<%= fact.upcase %>: ${{ matrix.<%= fact %> }}
+          <%- end -%>
 <%- else -%>
 # This module contains no acceptance tests - this is a placeholder for
 # modulesync.

--- a/moduleroot/.github/workflows/cron.yml.erb
+++ b/moduleroot/.github/workflows/cron.yml.erb
@@ -89,6 +89,12 @@ jobs:
         puppet:
           - "6"
           - "5"
+        <%- @configs['beaker_fact_matrix'].each do |option, values| -%>
+        <%= option %>:
+        <%- values.each do |value| -%>
+          - "<%= value %>"
+        <%- end -%>
+        <%- end -%>
         <%- if @configs['excludes'].any? -%>
         exclude:
         <%- @configs['excludes'].each do |exclude| -%>
@@ -97,7 +103,13 @@ jobs:
         <%- end -%>
         <%- end -%>
         <%- end -%>
-    name: Puppet ${{ matrix.puppet }} - ${{ matrix.setfile }}
+    <%-
+      name = ['Puppet ${{ matrix.puppet }}', '${{ matrix.setfile }}']
+      @configs['beaker_fact_matrix'].each_key do |option|
+        name << "#{option.tr('_', ' ').capitalize} ${{ matrix.#{option} }}"
+      end
+    -%>
+    name: <%= name.join(' - ') %>
     steps:
       - name: Enable IPv6 on docker
         run: |
@@ -125,4 +137,7 @@ jobs:
         env:
           BEAKER_PUPPET_COLLECTION: puppet${{ matrix.puppet }}
           BEAKER_setfile: ${{ matrix.setfile }}
+          <%- @configs['beaker_fact_matrix'].keys.each do |fact| -%>
+          BEAKER_FACTER_<%= fact.upcase %>: ${{ matrix.<%= fact %> }}
+          <%- end -%>
 <%- end -%>


### PR DESCRIPTION
This is already used by puppet-pulpcore to test both 3.6 and 3.7. It should also be used by puppet-foreman and puppet-foreman_proxy to test its multiple versions.