### PR TITLE
Use shorter beaker setfile names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'modulesync', '~> 2.0'
-gem 'puppet_metadata', '~> 0.1.0'
+gem 'puppet_metadata', '~> 0.2.0'

--- a/moduleroot/.github/workflows/acceptance.yml.erb
+++ b/moduleroot/.github/workflows/acceptance.yml.erb
@@ -34,8 +34,9 @@ jobs:
         setfile:
           <%- require 'puppet_metadata' -%>
           <%- metadata_file = File.join(@metadata[:workdir], 'metadata.json') -%>
-          <%- PuppetMetadata.read(metadata_file).beaker_setfiles(use_fqdn: true, pidfile_workaround: @configs['pidfile_workaround']) do |setfile| -%>
-          - <%= setfile %>
+          <%- PuppetMetadata.read(metadata_file).beaker_setfiles(use_fqdn: true, pidfile_workaround: @configs['pidfile_workaround']) do |setfile, name| -%>
+          - value: <%= setfile %>
+            name: <%= name %>
           <%- end -%>
         puppet:
           - "6"
@@ -55,7 +56,7 @@ jobs:
         <%- end -%>
         <%- end -%>
     <%-
-      name = ['Puppet ${{ matrix.puppet }}', '${{ matrix.setfile }}']
+      name = ['Puppet ${{ matrix.puppet }}', '${{ matrix.setfile.name }}']
       @configs['beaker_fact_matrix'].each_key do |option|
         name << "#{option.tr('_', ' ').capitalize} ${{ matrix.#{option} }}"
       end
@@ -87,7 +88,7 @@ jobs:
         run: bundle exec rake beaker
         env:
           BEAKER_PUPPET_COLLECTION: puppet${{ matrix.puppet }}
-          BEAKER_setfile: ${{ matrix.setfile }}
+          BEAKER_setfile: ${{ matrix.setfile.value }}
           <%- @configs['beaker_fact_matrix'].keys.each do |fact| -%>
           BEAKER_FACTER_<%= fact.upcase %>: ${{ matrix.<%= fact %> }}
           <%- end -%>

--- a/moduleroot/.github/workflows/cron.yml.erb
+++ b/moduleroot/.github/workflows/cron.yml.erb
@@ -83,8 +83,9 @@ jobs:
         setfile:
           <%- require 'puppet_metadata' -%>
           <%- metadata_file = File.join(@metadata[:workdir], 'metadata.json') -%>
-          <%- PuppetMetadata.read(metadata_file).beaker_setfiles(use_fqdn: true, pidfile_workaround: @configs['pidfile_workaround']) do |setfile| -%>
-          - <%= setfile %>
+          <%- PuppetMetadata.read(metadata_file).beaker_setfiles(use_fqdn: true, pidfile_workaround: @configs['pidfile_workaround']) do |setfile, name| -%>
+          - value: <%= setfile %>
+            name: <%= name %>
           <%- end -%>
         puppet:
           - "6"
@@ -104,7 +105,7 @@ jobs:
         <%- end -%>
         <%- end -%>
     <%-
-      name = ['Puppet ${{ matrix.puppet }}', '${{ matrix.setfile }}']
+      name = ['Puppet ${{ matrix.puppet }}', '${{ matrix.setfile.name }}']
       @configs['beaker_fact_matrix'].each_key do |option|
         name << "#{option.tr('_', ' ').capitalize} ${{ matrix.#{option} }}"
       end
@@ -136,7 +137,7 @@ jobs:
         run: bundle exec rake beaker
         env:
           BEAKER_PUPPET_COLLECTION: puppet${{ matrix.puppet }}
-          BEAKER_setfile: ${{ matrix.setfile }}
+          BEAKER_setfile: ${{ matrix.setfile.value }}
           <%- @configs['beaker_fact_matrix'].keys.each do |fact| -%>
           BEAKER_FACTER_<%= fact.upcase %>: ${{ matrix.<%= fact %> }}
           <%- end -%>


### PR DESCRIPTION
Instead of centos7-64{hostname=centos7-64.example.com} it now prints just centos7 in the name.