### PR TITLE
Dynamically generate the acceptance matrix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
 gem 'modulesync', '~> 2.0'
-gem 'puppet_metadata', '~> 0.2.0'

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -42,6 +42,11 @@ Gemfile:
     options:
       groups:
       - 'development'
+  - gem: 'puppet_metadata'
+    version: '~> 0.3'
+    options:
+      groups:
+        - 'system_tests'
   - gem: 'voxpupuli-acceptance'
     version: '~> 0.3'
     options:

--- a/moduleroot/.github/workflows/acceptance.yml.erb
+++ b/moduleroot/.github/workflows/acceptance.yml.erb
@@ -3,6 +3,12 @@ name: Acceptance tests
 
 on: pull_request
 
+env:
+  BUNDLE_PATH: vendor/bundle
+  BUNDLE_WITHOUT: development:test
+  BUNDLE_JOBS: 4
+  BUNDLE_RETRY: 3
+
 jobs:
   build_cache:
     runs-on: ubuntu-latest
@@ -21,9 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler
-          bundle config path vendor/bundle
-          bundle config without 'development test'
-          bundle install --jobs 4 --retry 3
+          bundle install
 
   acceptance:
     needs: build_cache
@@ -81,9 +85,7 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler
-          bundle config path vendor/bundle
-          bundle config without 'development test'
-          bundle install --jobs 4 --retry 3
+          bundle install
       - name: Run tests
         run: bundle exec rake beaker
         env:

--- a/moduleroot/.github/workflows/acceptance.yml.erb
+++ b/moduleroot/.github/workflows/acceptance.yml.erb
@@ -10,8 +10,12 @@ env:
   BUNDLE_RETRY: 3
 
 jobs:
-  build_cache:
+  setup_matrix:
+    name: 'Setup Test Matrix'
     runs-on: ubuntu-latest
+    outputs:
+      setfiles: ${{ steps.get-setfiles.outputs.setfiles }}
+      puppet_major_versions: ${{ steps.get-setfiles.outputs.puppet_major_versions }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
@@ -29,23 +33,18 @@ jobs:
           gem install bundler
           bundle install
           bundle clean
+      - name: Setup Acceptance Test Matrix
+        id: get-setfiles
+        run: bundle exec metadata2gha-beaker --use-fqdn --pidfile-workaround <%= @configs['pidfile_workaround'] %>
 
   acceptance:
-    needs: build_cache
+    needs: setup_matrix
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        setfile:
-          <%- require 'puppet_metadata' -%>
-          <%- metadata_file = File.join(@metadata[:workdir], 'metadata.json') -%>
-          <%- PuppetMetadata.read(metadata_file).beaker_setfiles(use_fqdn: true, pidfile_workaround: @configs['pidfile_workaround']) do |setfile, name| -%>
-          - value: <%= setfile %>
-            name: <%= name %>
-          <%- end -%>
-        puppet:
-          - "6"
-          - "5"
+        setfile: ${{fromJson(needs.setup_matrix.outputs.setfiles)}}
+        puppet: ${{fromJson(needs.setup_matrix.outputs.puppet_major_versions)}}
         <%- @configs['beaker_fact_matrix'].each do |option, values| -%>
         <%= option %>:
         <%- values.each do |value| -%>

--- a/moduleroot/.github/workflows/acceptance.yml.erb
+++ b/moduleroot/.github/workflows/acceptance.yml.erb
@@ -28,6 +28,7 @@ jobs:
         run: |
           gem install bundler
           bundle install
+          bundle clean
 
   acceptance:
     needs: build_cache
@@ -86,6 +87,7 @@ jobs:
         run: |
           gem install bundler
           bundle install
+          bundle clean
       - name: Run tests
         run: bundle exec rake beaker
         env:

--- a/moduleroot/.github/workflows/cron.yml.erb
+++ b/moduleroot/.github/workflows/cron.yml.erb
@@ -52,9 +52,13 @@ jobs:
         run: bundle exec rake
 <%- if Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
 
-  build_cache:
+  setup_matrix:
+    name: 'Setup Test Matrix'
     if: github.repository == '<%= @configs[:namespace] %>/<%= @configs[:puppet_module] %>'
     runs-on: ubuntu-latest
+    outputs:
+      setfiles: ${{ steps.get-setfiles.outputs.setfiles }}
+      puppet_major_versions: ${{ steps.get-setfiles.outputs.puppet_major_versions }}
     env:
       BUNDLE_WITHOUT: development:test
     steps:
@@ -78,23 +82,21 @@ jobs:
           gem install bundler
           bundle install
           bundle clean
+      - name: Setup Acceptance Test Matrix
+        id: get-setfiles
+        run: bundle exec metadata2gha-beaker --use-fqdn --pidfile-workaround <%= @configs['pidfile_workaround'] %>
 
   acceptance:
     if: github.repository == '<%= @configs[:namespace] %>/<%= @configs[:puppet_module] %>'
-    needs: build_cache
+    needs: setup_matrix
     runs-on: ubuntu-latest
     env:
       BUNDLE_WITHOUT: development:test
     strategy:
       fail-fast: false
       matrix:
-        setfile:
-          <%- require 'puppet_metadata' -%>
-          <%- metadata_file = File.join(@metadata[:workdir], 'metadata.json') -%>
-          <%- PuppetMetadata.read(metadata_file).beaker_setfiles(use_fqdn: true, pidfile_workaround: @configs['pidfile_workaround']) do |setfile, name| -%>
-          - value: <%= setfile %>
-            name: <%= name %>
-          <%- end -%>
+        setfile: ${{fromJson(needs.setup_matrix.outputs.setfiles)}}
+        puppet: ${{fromJson(needs.setup_matrix.outputs.puppet_major_versions)}}
         puppet:
           - "6"
           - "5"

--- a/moduleroot/.github/workflows/cron.yml.erb
+++ b/moduleroot/.github/workflows/cron.yml.erb
@@ -47,6 +47,7 @@ jobs:
         run: |
           gem install bundler
           bundle install
+          bundle clean
       - name: Run tests
         run: bundle exec rake
 <%- if Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
@@ -76,6 +77,7 @@ jobs:
         run: |
           gem install bundler
           bundle install
+          bundle clean
 
   acceptance:
     if: github.repository == '<%= @configs[:namespace] %>/<%= @configs[:puppet_module] %>'
@@ -137,6 +139,7 @@ jobs:
         run: |
           gem install bundler
           bundle install
+          bundle clean
       - name: Run tests
         run: bundle exec rake beaker
         env:

--- a/moduleroot/.github/workflows/cron.yml.erb
+++ b/moduleroot/.github/workflows/cron.yml.erb
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '4 4 * * *'
 
+env:
+  BUNDLE_PATH: vendor/bundle
+  BUNDLE_JOBS: 4
+  BUNDLE_RETRY: 3
+
 jobs:
   unit:
     if: github.repository == '<%= @configs[:namespace] %>/<%= @configs[:puppet_module] %>'
@@ -23,6 +28,7 @@ jobs:
           - ruby: "2.4"
             puppet: "6"
     env:
+      BUNDLE_WITHOUT: development:system_tests
       PUPPET_VERSION: "${{ matrix.puppet }}.0"
     name: Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
@@ -40,9 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler
-          bundle config path vendor/bundle
-          bundle config without 'development system_tests'
-          bundle install --jobs 4 --retry 3
+          bundle install
       - name: Run tests
         run: bundle exec rake
 <%- if Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
@@ -50,6 +54,8 @@ jobs:
   build_cache:
     if: github.repository == '<%= @configs[:namespace] %>/<%= @configs[:puppet_module] %>'
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_WITHOUT: development:test
     steps:
       - name: Enable IPv6 on docker
         run: |
@@ -69,14 +75,14 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler
-          bundle config path vendor/bundle
-          bundle config without 'development test'
-          bundle install --jobs 4 --retry 3
+          bundle install
 
   acceptance:
     if: github.repository == '<%= @configs[:namespace] %>/<%= @configs[:puppet_module] %>'
     needs: build_cache
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_WITHOUT: development:test
     strategy:
       fail-fast: false
       matrix:
@@ -130,9 +136,7 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler
-          bundle config path vendor/bundle
-          bundle config without 'development test'
-          bundle install --jobs 4 --retry 3
+          bundle install
       - name: Run tests
         run: bundle exec rake beaker
         env:

--- a/moduleroot/.github/workflows/unit.yml.erb
+++ b/moduleroot/.github/workflows/unit.yml.erb
@@ -44,5 +44,6 @@ jobs:
         run: |
           gem install bundler
           bundle install
+          bundle clean
       - name: Run tests
         run: bundle exec rake

--- a/moduleroot/.github/workflows/unit.yml.erb
+++ b/moduleroot/.github/workflows/unit.yml.erb
@@ -2,6 +2,12 @@ name: Unit tests
 
 on: pull_request
 
+env:
+  BUNDLE_PATH: vendor/bundle
+  BUNDLE_WITHOUT: development:system_tests
+  BUNDLE_JOBS: 4
+  BUNDLE_RETRY: 3
+
 jobs:
   unit:
     runs-on: ubuntu-latest
@@ -37,8 +43,6 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler
-          bundle config path vendor/bundle
-          bundle config without 'development system_tests'
-          bundle install --jobs 4 --retry 3
+          bundle install
       - name: Run tests
         run: bundle exec rake


### PR DESCRIPTION
puppet_metadata 0.3 [will include a helper for beaker on Github Actions](https://github.com/voxpupuli/puppet_metadata/pull/11). This means it's possible to modify metadata.json without changing the Github Actions. In order to do so, the build_cache step is changed into a setup_matrix step.

It also cleans up bundler use with more environment variables.