### PR TITLE
Remove puppet-pulp from managed modules

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -10,7 +10,6 @@
 - puppet-katello
 - puppet-katello_devel
 - puppet-motd
-- puppet-pulp
 - puppet-pulpcore
 - puppet-puppet
 - puppet-puppetserver_foreman


### PR DESCRIPTION
Now that Pulp 2 has been dropped, there's no need to keep this module updated.