### PR TITLE
Update to voxpupuli-acceptance 1.0

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -45,7 +45,7 @@ Gemfile:
       groups:
       - 'development'
   - gem: 'voxpupuli-acceptance'
-    version: '~> 0.3'
+    version: '~> 1.0'
     options:
       groups:
         - 'system_tests'

--- a/moduleroot/spec/spec_helper_acceptance.rb.erb
+++ b/moduleroot/spec/spec_helper_acceptance.rb.erb
@@ -12,31 +12,6 @@ configure_beaker(modules: :fixtures) do |host|
     # refresh check if cache needs refresh on next yum command
     on host, 'yum clean expire-cache'
   end
-
-  local_setup = File.join(__dir__, 'setup_acceptance_node.pp')
-  if File.exist?(local_setup)
-    puts "Configuring #{host} by applying #{local_setup}"
-    apply_manifest_on(host, File.read(local_setup), catch_failures: true)
-  end
-end
-
-shared_examples 'a idempotent resource' do
-  it 'applies with no errors' do
-    apply_manifest(pp, catch_failures: true)
-  end
-
-  it 'applies a second time without changes' do
-    apply_manifest(pp, catch_changes: true)
-  end
-end
-
-shared_examples 'the example' do |name|
-  let(:pp) do
-    path = File.join(File.dirname(__dir__), 'examples', name)
-    File.read(path)
-  end
-
-  include_examples 'a idempotent resource'
 end
 
 Dir["./spec/support/acceptance/**/*.rb"].sort.each { |f| require f }


### PR DESCRIPTION
Our local changes have been integrated into voxpupuli-acceptance. There is a slight difference in how the examples are written so modules need manual conversion.
* [x] https://github.com/theforeman/puppet-foreman/pull/954
* [x] https://github.com/theforeman/puppet-certs/pull/338
* [x] https://github.com/theforeman/puppet-dhcp/pull/188
* [x] https://github.com/theforeman/puppet-dns/pull/187
* [ ] https://github.com/theforeman/puppet-foreman_proxy/pull/678
* [x] https://github.com/theforeman/puppet-foreman_proxy_content/pull/359
* [x] https://github.com/theforeman/puppet-katello/pull/414
* [x] https://github.com/theforeman/puppet-pulpcore/pull/195
* [x] https://github.com/theforeman/puppet-puppet/pull/789
* [x] https://github.com/theforeman/puppet-qpid/pull/166
* [x] https://github.com/theforeman/puppet-tftp/pull/118