### PR TITLE
Fix beaker tests due to puppetlabs_spec_helper 4.x

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -32,6 +32,9 @@ Gemfile:
       - 'test'
   - gem: voxpupuli-test
     version: '~> 1.4'
+    options:
+      groups:
+      - 'test'
   - gem: github_changelog_generator
     version: '>= 1.15.0'
     options:
@@ -46,6 +49,10 @@ Gemfile:
       - 'development'
   - gem: 'voxpupuli-acceptance'
     version: '~> 1.0'
+    options:
+      groups:
+        - 'system_tests'
+  - gem: 'puppetlabs_spec_helper'
     options:
       groups:
         - 'system_tests'

--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -15,7 +15,7 @@ jobs:
       puppet_major_versions: ${{ steps.get_outputs.outputs.puppet_major_versions }}
       puppet_unit_test_matrix: ${{ steps.get_outputs.outputs.puppet_unit_test_matrix }}
     env:
-      BUNDLE_WITHOUT: development:release
+      BUNDLE_WITHOUT: development:system_tests:release
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -1,10 +1,26 @@
 # This file is managed centrally by modulesync
 #   https://github.com/theforeman/foreman-installer-modulesync
 
-require 'voxpupuli/test/rake'
+# Attempt to load voxupuli-test (which pulls in puppetlabs_spec_helper),
+# otherwise attempt to load it directly.
+begin
+  require 'voxpupuli/test/rake'
+rescue LoadError
+  begin
+    require 'puppetlabs_spec_helper/rake_tasks'
+  rescue LoadError
+  end
+end
 
-# We use fixtures in our modules, which is not the default
-task :beaker => 'spec_prep'
+# load optional tasks for acceptance
+# only available if gem group releases is installed
+begin
+  require 'voxpupuli/acceptance/rake'
+rescue LoadError
+else
+  # We use fixtures in our modules, which is not the default
+  task :beaker => 'spec_prep'
+end
 
 # blacksmith isn't always present, e.g. on Travis with --without development
 begin


### PR DESCRIPTION
In puppetlabs_spec_helper 4.x the beaker task was removed. This loads it from voxpupuli-aceptance. puppetlabs_spec_helper is added for spec_prep.

* [x] https://github.com/theforeman/puppet-candlepin/pull/204
* [x] https://github.com/theforeman/puppet-certs/pull/378
* [x] https://github.com/theforeman/puppet-dhcp/pull/196
* [x] https://github.com/theforeman/puppet-dns/pull/197
* [x] https://github.com/theforeman/puppet-foreman/pull/980
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/694
* [x] https://github.com/theforeman/puppet-foreman_proxy_content/pull/381
* [x] https://github.com/theforeman/puppet-git/pull/82
* [ ] https://github.com/theforeman/puppet-katello/pull/429
* [x] https://github.com/theforeman/puppet-katello_devel/pull/268
* [x] https://github.com/theforeman/puppet-pulpcore/pull/224
* [ ] https://github.com/theforeman/puppet-puppet/pull/798
* [x] https://github.com/theforeman/puppet-puppetserver_foreman/pull/13
* [x] https://github.com/theforeman/puppet-qpid/pull/172
* [x] https://github.com/theforeman/puppet-tftp/pull/124