### PR TITLE
Pin rdoc to < 6.4

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -10,4 +10,7 @@ gem 'rake'
 gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %><%= ", #{gem['options'].inspect}" if gem['options'] %><%= " if RUBY_VERSION #{gem['ruby_version']}" if (gem['ruby_version']) %>
 <% end -%>
 
+# Pin rdoc to prevent updating bundled psych (https://github.com/ruby/rdoc/commit/ebe185c8775b2afe844eb3da6fa78adaa79e29a4)
+gem 'rdoc', '< 6.4'
+
 # vim:ft=ruby


### PR DESCRIPTION
rdoc 6.4.0 started to pull in an updated psych, which Puppet is incompatible with for now. A [commit](https://github.com/puppetlabs/puppet/commit/6084fcb53122806877dd4dcc37ad90fa2d340827) has been merged, but it's unclear when that will be released.

* [x] https://github.com/theforeman/puppet-candlepin/pull/212
* [x] https://github.com/theforeman/puppet-certs/pull/387
* [x] https://github.com/theforeman/puppet-dhcp/pull/207
* [x] https://github.com/theforeman/puppet-dns/pull/200
* [x] https://github.com/theforeman/puppet-foreman/pull/1014
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/721
* [x] https://github.com/theforeman/puppet-foreman_proxy_content/pull/394
* [x] https://github.com/theforeman/puppet-git/pull/83
* [x] https://github.com/theforeman/puppet-katello/pull/438
* [x] https://github.com/theforeman/puppet-katello_devel/pull/271
* [x] https://github.com/theforeman/puppet-puppet/pull/819
* [x] https://github.com/theforeman/puppet-puppetserver_foreman/pull/17
* [x] https://github.com/theforeman/puppet-tftp/pull/130