### PR TITLE
Use gha-puppet's reusable workflows

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -41,7 +41,7 @@ Gemfile:
       groups:
       - 'development'
   - gem: 'puppet_metadata'
-    version: '~> 0.3'
+    version: '~> 1.3'
   - gem: puppet-blacksmith
     version: '>= 6.0.0'
     options:
@@ -68,6 +68,6 @@ spec/spec_helper.rb:
   requires: []
   custom_facts: []
 spec/spec_helper_acceptance.rb:
-  install_epel: false
+  locale_workaround: false
 Rakefile:
   param_docs_pattern: []

--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -1,3 +1,4 @@
+---
 name: CI
 
 on:
@@ -5,100 +6,21 @@ on:
   schedule:
     - cron: '4 4 * * *'
 
+
+concurrency:
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
-  setup_matrix:
-    if: github.event_name != 'schedule' || github.repository_owner == '<%= @configs[:namespace] %>'
-    name: 'Setup Test Matrix'
-    runs-on: ubuntu-latest
-    outputs:
-      beaker_setfiles: ${{ steps.get_outputs.outputs.beaker_setfiles }}
-      puppet_major_versions: ${{ steps.get_outputs.outputs.puppet_major_versions }}
-      puppet_unit_test_matrix: ${{ steps.get_outputs.outputs.puppet_unit_test_matrix }}
-    env:
-      BUNDLE_WITHOUT: development:system_tests:release
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '2.7'
-          bundler-cache: true
-      - name: Run rake check
-        run: bundle exec rake check
-      - name: Run rake validate
-        run: bundle exec rake validate
-      - name: Run rake lint
-        run: bundle exec rake lint
-      - name: Setup Test Matrix
-        id: get_outputs
-        run: bundle exec metadata2gha --use-fqdn --pidfile-workaround <%= @configs['pidfile_workaround'] %>
-
-  unit:
-    needs: setup_matrix
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{fromJson(needs.setup_matrix.outputs.puppet_unit_test_matrix)}}
-    env:
-      BUNDLE_WITHOUT: development:system_tests:release
-      PUPPET_VERSION: "${{ matrix.puppet }}.0"
-    name: Unit / Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-      - name: Run tests
-        run: bundle exec rake parallel_spec
+  puppet:
+    name: Puppet
 <%- if Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
-
-  acceptance:
-    needs: setup_matrix
-    runs-on: ubuntu-latest
-    env:
-      BUNDLE_WITHOUT: development:test:release
-    strategy:
-      fail-fast: false
-      matrix:
-        setfile: ${{fromJson(needs.setup_matrix.outputs.beaker_setfiles)}}
-        puppet: ${{fromJson(needs.setup_matrix.outputs.puppet_major_versions)}}
-        <%- @configs['beaker_fact_matrix'].each do |option, values| -%>
-        <%= option %>:
-        <%- values.each do |value| -%>
-          - "<%= value %>"
-        <%- end -%>
-        <%- end -%>
-        <%- if @configs['excludes'].any? -%>
-        exclude:
-        <%- @configs['excludes'].each do |exclude| -%>
-        <%- exclude.each do |key, value| -%>
-          <%= key == exclude.first.first ? '-' : ' ' %> <%= key %>: "<%= value %>"
-        <%- end -%>
-        <%- end -%>
-        <%- end -%>
-    <%-
-      name = ['Acceptance / ${{ matrix.puppet.name }}', '${{ matrix.setfile.name }}']
-      @configs['beaker_fact_matrix'].each_key do |option|
-        name << "#{option.tr('_', ' ').capitalize} ${{ matrix.#{option} }}"
-      end
-    -%>
-    name: <%= name.join(' - ') %>
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '2.7'
-          bundler-cache: true
-      - name: Run tests
-        run: bundle exec rake beaker
-        env:
-          BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet.collection }}
-          BEAKER_setfile: ${{ matrix.setfile.value }}
-          <%- @configs['beaker_fact_matrix'].keys.each do |fact| -%>
-          BEAKER_FACTER_<%= fact.upcase %>: ${{ matrix.<%= fact %> }}
-          <%- end -%>
+    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v1
+    with:
+      pidfile_workaround: '<%= @configs['pidfile_workaround'] %>'
+<%- else -%>
+    uses: voxpupuli/gha-puppet/.github/workflows/basic.yml@v1
+    with:
 <%- end -%>
+      rubocop: false
+      cache-version: '1'

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -3,7 +3,7 @@
 
 source 'https://rubygems.org'
 
-gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 5.5', groups: ['development', 'test']
+gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '>= 5.5', groups: ['development', 'test']
 gem 'rake'
 
 <% (@configs['required'] + (@configs['extra'] || [])).each do |gem| -%>

--- a/moduleroot/spec/spec_helper_acceptance.rb.erb
+++ b/moduleroot/spec/spec_helper_acceptance.rb.erb
@@ -12,6 +12,15 @@ configure_beaker(modules: :fixtures) do |host|
     # refresh check if cache needs refresh on next yum command
     on host, 'yum clean expire-cache'
   end
+  <%- if @configs['locale_workaround'] -%>
+
+  # In Puppet 7 the locale ends up being C.UTF-8 if it isn't passed.
+  # This locale doesn't exist in EL7 and won't be supported either.
+  # At least PostgreSQL runs into this.
+  if host['hypervisor'] == 'docker' && host['platform'] == 'el-7-x86_64'
+    ENV['LANG'] = 'en_US.UTF-8'
+  end
+  <%- end -%>
 end
 
 Dir["./spec/support/acceptance/**/*.rb"].sort.each { |f| require f }


### PR DESCRIPTION
This changes the CI to use gha-puppet. The goal of gha-puppet is to avoid templating huge workflows. Rather it should be short.

It changes PUPPET_VERSION to PUPPET_GEM_VERSION to be compatible with the action. This is done to align with the larger ecosystem. PUPPET_VERSION is also used by beaker-puppet_install_helper but with a different syntax so it always conflicted.

For now Rubocop is turned off since none of our modules are ready for it.

* [x] https://github.com/theforeman/puppet-candlepin/pull/216
* [x] https://github.com/theforeman/puppet-certs/pull/393
* [x] https://github.com/theforeman/puppet-dhcp/pull/212
* [x] https://github.com/theforeman/puppet-dns/pull/208
* [x] https://github.com/theforeman/puppet-foreman/pull/1032
* [x] https://github.com/theforeman/puppet-foreman_proxy/pull/731
* [x] https://github.com/theforeman/puppet-foreman_proxy_content/pull/403
* [x] https://github.com/theforeman/puppet-git/pull/87
* [x] https://github.com/theforeman/puppet-katello/pull/442
* [x] https://github.com/theforeman/puppet-katello_devel/pull/272
* [x] puppet-motd
* [x] https://github.com/theforeman/puppet-pulpcore/pull/248
* [x] https://github.com/theforeman/puppet-puppet/pull/827
* [x] https://github.com/theforeman/puppet-puppetserver_foreman/pull/20
* [x] https://github.com/theforeman/puppet-qpid/pull/177
* [x] https://github.com/theforeman/puppet-tftp/pull/133