### PR TITLE
Add metadata_deps job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'metadata_json_deps', '~> 0.5.0'
 gem 'modulesync', '~> 2.0'
 gem 'puppet_metadata', '~> 1.0'
+gem 'rake', '~> 13.0'

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ across all of the Foreman installer modules.
 A full description of ModuleSync can be found in [ModuleSync's
 README](https://github.com/puppetlabs/modulesync).
 
+## Bulk updating of module dependencies
+
+You can use [metadata_json_deps](https://github.com/ekohl/metadata_json_deps) to verify all modules allow the latest (released) modules on the [Forge](https://forge.puppet.com/). See its README for details, but it boils down to:
+
+```console
+$ bundle exec rake metadata_deps
+...
+$ bundle exec bump-dependency-upper-bound puppetlabs/stdlib 8.0.0 modules/*/*/metadata.json
+...
+```
+
 ## Releasing
 
 ### Setup

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require 'metadata_json_deps'
+
+desc 'Run metadata-json-deps'
+task :metadata_deps do
+  files = FileList['modules/*/*/metadata.json']
+  MetadataJsonDeps.run(files)
+end


### PR DESCRIPTION
This job can verify if all dependencies in modules allow the newest version on the forge.

Sample output:

```console
$ be rake metadata_deps
Checking modules/theforeman/puppet-candlepin/metadata.json
  puppetlabs/stdlib (>= 4.2.0 < 8.0.0) doesn't match 8.1.0
  puppet/extlib (>= 3.0.0 < 6.0.0) doesn't match 6.0.0
Checking modules/theforeman/puppet-certs/metadata.json
  puppetlabs-stdlib (>= 4.25.0 < 8.0.0) doesn't match 8.1.0
  puppet-extlib (>= 3.0.0 < 6.0.0) doesn't match 6.0.0
Checking modules/theforeman/puppet-dhcp/metadata.json
Checking modules/theforeman/puppet-dns/metadata.json
Checking modules/theforeman/puppet-foreman/metadata.json
Checking modules/theforeman/puppet-foreman_proxy/metadata.json
Checking modules/theforeman/puppet-foreman_proxy_content/metadata.json
  puppetlabs/stdlib (>= 4.25.0 < 8.0.0) doesn't match 8.1.0
  puppet/extlib (>= 3.0.0 < 6.0.0) doesn't match 6.0.0
  puppetlabs/apache (>= 2.0.0 < 7.0.0) doesn't match 7.0.0
Checking modules/theforeman/puppet-git/metadata.json
  puppetlabs/stdlib (>= 4.13.0 < 8.0.0) doesn't match 8.1.0
Checking modules/theforeman/puppet-katello/metadata.json
  puppet/extlib (>= 3.0.0 < 6.0.0) doesn't match 6.0.0
  puppetlabs/apache (>= 1.0.0 < 7.0.0) doesn't match 7.0.0
  puppetlabs/stdlib (>= 4.25.1 < 8.0.0) doesn't match 8.1.0
Checking modules/theforeman/puppet-katello_devel/metadata.json
Checking modules/theforeman/puppet-motd/metadata.json
  puppetlabs/stdlib (>= 4.25.0 < 8.0.0) doesn't match 8.1.0
Checking modules/theforeman/puppet-pulpcore/metadata.json
  puppetlabs/stdlib (>= 4.25.0 < 8.0.0) doesn't match 8.1.0
  puppetlabs/apache (>= 5.4.0 < 7.0.0) doesn't match 7.0.0
  puppet/extlib (>= 3.0.0 < 6.0.0) doesn't match 6.0.0
Checking modules/theforeman/puppet-puppet/metadata.json
Checking modules/theforeman/puppet-puppetserver_foreman/metadata.json
Checking modules/theforeman/puppet-qpid/metadata.json
Checking modules/theforeman/puppet-tftp/metadata.json
```

And yes, this does show that I forgot a step in our release process for Foreman 3.2. Having this script in place makes it easier to prevent this in the future.