### PR TITLE
Update to voxpupuli-test 5

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -31,7 +31,7 @@ Gemfile:
       groups:
       - 'test'
   - gem: voxpupuli-test
-    version: '~> 1.4'
+    version: '~> 5.0'
     options:
       groups:
       - 'test'

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -9,6 +9,8 @@ require '<%= r %>'
 <% end -%>
 require 'voxpupuli/test/spec_helper'
 
+add_mocked_facts!
+
 <% if @configs['custom_facts'].any? -%>
 <% @configs['custom_facts'].each do |fact| -%>
 add_custom_fact :<%= fact['name'] %>, <%= fact['value'].inspect %> # <%= fact['source'] %>


### PR DESCRIPTION
It is stricter in puppet-lint. PRs to our modules are:

* https://github.com/theforeman/puppet-candlepin/pull/221
* https://github.com/theforeman/puppet-certs/pull/401
* https://github.com/theforeman/puppet-dhcp/pull/214
* https://github.com/theforeman/puppet-dns/pull/214
* https://github.com/theforeman/puppet-foreman/pull/1063
* https://github.com/theforeman/puppet-foreman_proxy/pull/763
* https://github.com/theforeman/puppet-foreman_proxy_content/pull/421
* https://github.com/theforeman/puppet-git/pull/89
* https://github.com/theforeman/puppet-katello/pull/453
* https://github.com/theforeman/puppet-katello_devel/pull/281
* https://github.com/theforeman/puppet-motd/pull/11
* https://github.com/theforeman/puppet-pulpcore/pull/258
* https://github.com/theforeman/puppet-puppetserver_foreman/pull/22
* https://github.com/theforeman/puppet-qpid/pull/179
* https://github.com/theforeman/puppet-tftp/pull/135