### PR TITLE
Drop puppet-git from managed modules

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -7,7 +7,6 @@
 - puppet-foreman_proxy
 - puppet-foreman_proxy_content
 - puppet-foreman_scap_client
-- puppet-git
 - puppet-katello
 - puppet-katello_devel
 - puppet-motd


### PR DESCRIPTION
We've dropped the dependency on this and have moved to puppetlabs-vcsrepo.