### PR TITLE
Update gem versions in modules

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -31,7 +31,7 @@ Gemfile:
       groups:
       - 'test'
   - gem: voxpupuli-test
-    version: '~> 5.0'
+    version: '~> 7.0'
     options:
       groups:
       - 'test'
@@ -41,14 +41,14 @@ Gemfile:
       groups:
       - 'development'
   - gem: 'puppet_metadata'
-    version: '~> 1.3'
+    version: '~> 3.0'
   - gem: puppet-blacksmith
     version: '>= 6.0.0'
     options:
       groups:
       - 'development'
   - gem: 'voxpupuli-acceptance'
-    version: '~> 1.0'
+    version: '~> 2.0'
     options:
       groups:
         - 'system_tests'

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -5,28 +5,7 @@ Gemfile:
     options:
       groups:
       - 'test'
-  - gem: puppet-lint-empty_string-check
-    options:
-      groups:
-      - 'test'
-  - gem: puppet-lint-file_ensure-check
-    options:
-      groups:
-      - 'test'
-  - gem: puppet-lint-param-docs
-    version: '>= 1.3.0'
-    options:
-      groups:
-      - 'test'
   - gem: puppet-lint-spaceship_operator_without_tag-check
-    options:
-      groups:
-      - 'test'
-  - gem: puppet-lint-strict_indent-check
-    options:
-      groups:
-      - 'test'
-  - gem: puppet-lint-undef_in_function-check
     options:
       groups:
       - 'test'

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -21,7 +21,7 @@ Gemfile:
       groups:
       - 'development'
   - gem: 'puppet_metadata'
-    version: '~> 3.0'
+    version: '~> 3.3'
   - gem: puppet-blacksmith
     version: '>= 6.0.0'
     options:

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -6,6 +6,7 @@ Gemfile:
       groups:
       - 'test'
   - gem: puppet-lint-spaceship_operator_without_tag-check
+    version: '~> 1.0'
     options:
       groups:
       - 'test'

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -21,7 +21,7 @@ Gemfile:
       groups:
       - 'development'
   - gem: 'puppet_metadata'
-    version: '~> 3.3'
+    version: '~> 3.4'
   - gem: puppet-blacksmith
     version: '>= 6.0.0'
     options:

--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -16,6 +16,9 @@ jobs:
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v2
     with:
       pidfile_workaround: '<%= @configs['pidfile_workaround'] %>'
+<%- if @configs['beaker_facter'] -%>
+      beaker_facter: '<%= @configs['beaker_facter'] %>'
+<%- end -%>
 <%- else -%>
     uses: voxpupuli/gha-puppet/.github/workflows/basic.yml@v2
     with:

--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -3,8 +3,6 @@ name: CI
 
 on:
   pull_request:
-  schedule:
-    - cron: '4 4 * * *'
 
 
 concurrency:

--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -13,11 +13,11 @@ jobs:
   puppet:
     name: Puppet
 <%- if Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
-    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v1
+    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v2
     with:
       pidfile_workaround: '<%= @configs['pidfile_workaround'] %>'
 <%- else -%>
-    uses: voxpupuli/gha-puppet/.github/workflows/basic.yml@v1
+    uses: voxpupuli/gha-puppet/.github/workflows/basic.yml@v2
     with:
 <%- end -%>
       rubocop: false

--- a/moduleroot/.gitignore.erb
+++ b/moduleroot/.gitignore.erb
@@ -29,7 +29,8 @@ vendor/
 .ruby-*
 
 ## rspec
-spec/fixtures/
+spec/fixtures/manifests
+spec/fixtures/modules
 junit/
 
 ## Puppet module

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -3,14 +3,11 @@
 
 source 'https://rubygems.org'
 
-gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '>= 5.5', groups: ['development', 'test']
+gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '>= 7', groups: ['development', 'test']
 gem 'rake'
 
 <% (@configs['required'] + (@configs['extra'] || [])).each do |gem| -%>
 gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %><%= ", #{gem['options'].inspect}" if gem['options'] %><%= " if RUBY_VERSION #{gem['ruby_version']}" if (gem['ruby_version']) %>
 <% end -%>
-
-# Pin rdoc to prevent updating bundled psych (https://github.com/ruby/rdoc/commit/ebe185c8775b2afe844eb3da6fa78adaa79e29a4)
-gem 'rdoc', '< 6.4'
 
 # vim:ft=ruby

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -3,7 +3,7 @@
 
 source 'https://rubygems.org'
 
-gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '>= 7', groups: ['development', 'test']
+gem 'puppet', ENV.fetch('PUPPET_GEM_VERSION', '>= 7'), groups: ['development', 'test']
 gem 'rake'
 
 <% (@configs['required'] + (@configs['extra'] || [])).each do |gem| -%>


### PR DESCRIPTION
This should bring CI support to test Puppet 8.

* [ ] https://github.com/theforeman/puppet-candlepin/pull/241
* [ ] https://github.com/theforeman/puppet-certs/pull/427
* [ ] https://github.com/theforeman/puppet-dhcp/pull/225
* [ ] https://github.com/theforeman/puppet-dns/pull/240
* [ ] https://github.com/theforeman/puppet-foreman/pull/1133
* [ ] https://github.com/theforeman/puppet-foreman_proxy/pull/814
* [ ] https://github.com/theforeman/puppet-foreman_proxy_content/pull/461
* [ ] https://github.com/theforeman/puppet-foreman_scap_client/pull/75
* [ ] https://github.com/theforeman/puppet-katello/pull/476
* [ ] https://github.com/theforeman/puppet-katello_devel/pull/294
* [ ] https://github.com/theforeman/puppet-katello_devel/pull/297
* [ ] https://github.com/theforeman/puppet-motd/pull/15
* [ ] https://github.com/theforeman/puppet-pulpcore/pull/309
* [ ] https://github.com/theforeman/puppet-puppet/pull/888
* [ ] https://github.com/theforeman/puppet-puppetserver_foreman/pull/36
* [ ] https://github.com/theforeman/puppet-tftp/pull/143