### PR TITLE
Update release-module to use an API key

### DIFF
--- a/bin/release-module
+++ b/bin/release-module
@@ -11,7 +11,7 @@ git verify-tag "$VERSION"
 git push --follow-tags
 
 rm -f REFERENCE.md
-if basename "$PWD" | grep -E -q '^puppet-(candlepin|dns|dhcp|git|pulp|pulpcore|motd|qpid|tftp|foreman_simple_user)$' ; then
+if basename "$PWD" | grep -E -q '^puppet-(candlepin|dns|dhcp|git|pulp|pulpcore|motd|qpid|tftp|foreman_simple_user|foreman_scap_client)$' ; then
 	bundle exec rake strings:generate:reference
 fi
 

--- a/bin/release-module
+++ b/bin/release-module
@@ -16,5 +16,4 @@ if basename "$PWD" | grep -E -q '^puppet-(candlepin|dns|dhcp|git|pulp|pulpcore|m
 fi
 
 BLACKSMITH_FORGE_USERNAME="$(jq -r .author metadata.json | tr '[:upper:]' '[:lower:]')"
-export BLACKSMITH_FORGE_USERNAME
-BLACKSMITH_FORGE_PASSWORD="$(gopass show "theforeman/shared/forge.puppet.com/$BLACKSMITH_FORGE_USERNAME" | head -n 1)" bundle exec rake module:clean module:push
+BLACKSMITH_FORGE_API_KEY="$(gopass show "theforeman/shared/forge.puppet.com/$BLACKSMITH_FORGE_USERNAME" api-key)" bundle exec rake module:clean module:push

--- a/bin/release-module
+++ b/bin/release-module
@@ -11,9 +11,10 @@ git verify-tag "$VERSION"
 git push --follow-tags
 
 rm -f REFERENCE.md
-if basename $PWD | grep -E -q '^puppet-(candlepin|dns|dhcp|git|pulp|pulpcore|motd|qpid|tftp|foreman_simple_user)$' ; then
+if basename "$PWD" | grep -E -q '^puppet-(candlepin|dns|dhcp|git|pulp|pulpcore|motd|qpid|tftp|foreman_simple_user)$' ; then
 	bundle exec rake strings:generate:reference
 fi
 
-export BLACKSMITH_FORGE_USERNAME="$(jq -r .author metadata.json | tr [A-Z] [a-z])"
-BLACKSMITH_FORGE_PASSWORD="$(gopass show theforeman/shared/forge.puppet.com/$BLACKSMITH_FORGE_USERNAME | head -n 1)" bundle exec rake module:clean module:push
+BLACKSMITH_FORGE_USERNAME="$(jq -r .author metadata.json | tr '[:upper:]' '[:lower:]')"
+export BLACKSMITH_FORGE_USERNAME
+BLACKSMITH_FORGE_PASSWORD="$(gopass show "theforeman/shared/forge.puppet.com/$BLACKSMITH_FORGE_USERNAME" | head -n 1)" bundle exec rake module:clean module:push


### PR DESCRIPTION
It's no longer possible to use username/password so the shared keystore is updated to have an API key.

Also makes it pass shellcheck and generates REFERENCE.md for foreman_scap_client.