### PR TITLE
Update to gha-puppet v3

### DIFF
--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -18,15 +18,14 @@ jobs:
   puppet:
     name: Puppet
 <%- if Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
-    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v2
+    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v3
     with:
       pidfile_workaround: '<%= @configs['pidfile_workaround'] %>'
 <%- if @configs['beaker_facter'] -%>
       beaker_facter: '<%= @configs['beaker_facter'] %>'
 <%- end -%>
 <%- else -%>
-    uses: voxpupuli/gha-puppet/.github/workflows/basic.yml@v2
+    uses: voxpupuli/gha-puppet/.github/workflows/basic.yml@v3
     with:
 <%- end -%>
       rubocop: false
-      cache-version: '1'


### PR DESCRIPTION
v2 runs on ubuntu-20.04 and that's being removed. It was needed for EL7, but we've dropped that.