### PR TITLE
Follow puppet-iop_advisor_engine rename

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -7,7 +7,7 @@
 - puppet-foreman_proxy
 - puppet-foreman_proxy_content
 - puppet-foreman_scap_client
-- puppet-iop-advisor-engine
+- puppet-iop_advisor_engine
 - puppet-katello
 - puppet-katello_devel
 - puppet-motd


### PR DESCRIPTION
This was renamed to follow Puppet module naming conventions.