### PR TITLE
voxupuli-acceptance: Update 4.1->4.2

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -28,7 +28,7 @@ Gemfile:
       groups:
       - 'development'
   - gem: 'voxpupuli-acceptance'
-    version: '~> 4.1'
+    version: '~> 4.2'
     options:
       groups:
         - 'system_tests'


### PR DESCRIPTION
4.2 brings and updated `curl_command` which allows us to configure client TLS certificates and username/password. We want to use that in puppet-foreman:

https://github.com/theforeman/puppet-foreman/pull/1251