### PR TITLE
Stop setting pidfile_workaround, not supported with gha-puppet v4

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -43,7 +43,6 @@ Gemfile:
 .github/workflows/ci.yml:
   beaker_fact_matrix: {}
   excludes: []
-  pidfile_workaround: false
 spec/spec_helper.rb:
   requires: []
   custom_facts: []

--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -20,7 +20,6 @@ jobs:
 <%- if Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v4
     with:
-      pidfile_workaround: '<%= @configs['pidfile_workaround'] %>'
 <%- if @configs['beaker_facter'] -%>
       beaker_facter: '<%= @configs['beaker_facter'] %>'
 <%- end -%>


### PR DESCRIPTION
Fixes: 8f1189db7d9dbacf2fd606cc9b66edde80b3b30a