### PR TITLE
Don't guard openvox gem in any group

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -3,7 +3,7 @@
 
 source 'https://rubygems.org'
 
-gem 'openvox', ENV.fetch('PUPPET_GEM_VERSION', '>= 8'), groups: ['development', 'test']
+gem 'openvox', ENV.fetch('PUPPET_GEM_VERSION', '>= 8')
 gem 'rake'
 
 <% (@configs['required'] + (@configs['extra'] || [])).each do |gem| -%>


### PR DESCRIPTION
puppet_fixtues wants puppet or openvox. This was present because of kafo_module_lint -> puppet-strings -> puppet. The Gemfile guarded openvox to development and test. it's not present in the systems_test group.